### PR TITLE
Fix for "cannot find symbol: class TargetApi" compilation error (build depends on the google annotations lib)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.android</groupId>
+            <artifactId>annotations</artifactId>
+            <version>4.1.1.4</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.zxing</groupId>
             <artifactId>core</artifactId>
             <version>2.2</version>


### PR DESCRIPTION
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] /Users/my-app/target/unpack/apklibs/com.embarkmobile_zxing-android-minimal_apklib_1.1.4/src/com/google/zxing/client/android/camera/exposure/FroyoExposureInterface.java:[19,25] package android.annotation does not exist
[ERROR] /Users/my-app/target/unpack/apklibs/com.embarkmobile_zxing-android-minimal_apklib_1.1.4/src/com/google/zxing/client/android/camera/exposure/FroyoExposureInterface.java:[23,1] cannot find symbol
symbol: class TargetApi
@TargetApi(8)
[ERROR] /Users/my-app/target/unpack/apklibs/com.embarkmobile_zxing-android-minimal_apklib_1.1.4/src/com/google/zxing/client/android/camera/open/GingerbreadOpenCameraInterface.java:[19,25] package android.annotation does not exist
[ERROR] /Users/my-app/target/unpack/apklibs/com.embarkmobile_zxing-android-minimal_apklib_1.1.4/src/com/google/zxing/client/android/camera/open/GingerbreadOpenCameraInterface.java:[27,1] cannot find symbol
symbol: class TargetApi
@TargetApi(9)
[ERROR] /Users/my-app/target/unpack/apklibs/com.embarkmobile_zxing-android-minimal_apklib_1.1.4/src/com/google/zxing/client/android/common/executor/HoneycombAsyncTaskExecInterface.java:[19,25] package android.annotation does not exist
[ERROR] /Users/my-app/target/unpack/apklibs/com.embarkmobile_zxing-android-minimal_apklib_1.1.4/src/com/google/zxing/client/android/common/executor/HoneycombAsyncTaskExecInterface.java:[26,1] cannot find symbol
symbol: class TargetApi
@TargetApi(11)
[INFO] 6 errors 
