### PR TITLE
Handler fix

### DIFF
--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/DecoderThread.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/DecoderThread.java
@@ -6,7 +6,6 @@ import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.Message;
 import android.util.Log;
-import android.view.Surface;
 
 import com.google.zxing.LuminanceSource;
 import com.google.zxing.PlanarYUVLuminanceSource;
@@ -14,8 +13,8 @@ import com.google.zxing.Result;
 import com.google.zxing.ResultPoint;
 import com.google.zxing.client.android.R;
 import com.journeyapps.barcodescanner.camera.CameraInstance;
-import com.journeyapps.barcodescanner.camera.DisplayConfiguration;
 
+import java.lang.ref.WeakReference;
 import java.util.List;
 
 /**
@@ -29,6 +28,7 @@ public class DecoderThread {
     private Handler handler;
     private Decoder decoder;
     private Handler resultHandler;
+    WeakReference<Handler> handlerWeakReference;
     private Rect cropRect;
 
     private final Handler.Callback callback = new Handler.Callback() {
@@ -76,6 +76,7 @@ public class DecoderThread {
         thread = new HandlerThread(TAG);
         thread.start();
         handler = new Handler(thread.getLooper(), callback);
+        handlerWeakReference=new WeakReference<>(handler);
         requestNextPreview();
     }
 
@@ -87,13 +88,15 @@ public class DecoderThread {
      */
     public void stop() {
         Util.validateMainThread();
-
+        handler.removeCallbacksAndMessages(null);
+        handler=null;
+        handlerWeakReference.clear();
         thread.quit();
     }
 
     private void requestNextPreview() {
         if (cameraInstance.isOpen()) {
-            cameraInstance.requestPreview(handler, R.id.zxing_decode);
+            cameraInstance.requestPreview(handlerWeakReference, R.id.zxing_decode);
         }
     }
 

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/CameraInstance.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/CameraInstance.java
@@ -9,6 +9,8 @@ import com.google.zxing.client.android.R;
 import com.journeyapps.barcodescanner.Size;
 import com.journeyapps.barcodescanner.Util;
 
+import java.lang.ref.WeakReference;
+
 /**
  *
  */
@@ -138,7 +140,7 @@ public class CameraInstance {
         return open;
     }
 
-    public void requestPreview(final Handler handler, final int message) {
+    public void requestPreview(final WeakReference<Handler> handler, final int message) {
         validateOpen();
 
         cameraThread.enqueue(new Runnable() {

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/CameraManager.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/CameraManager.java
@@ -30,6 +30,7 @@ import com.google.zxing.client.android.camera.open.OpenCameraInterface;
 import com.journeyapps.barcodescanner.Size;
 
 import java.io.IOException;
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -145,7 +146,6 @@ public final class CameraManager {
         }
         if (camera != null && previewing) {
             camera.stopPreview();
-            previewCallback.setHandler(null, 0);
             previewing = false;
         }
     }
@@ -363,7 +363,7 @@ public final class CameraManager {
      * @param handler The handler to send the message to.
      * @param message The what field of the message to be sent.
      */
-    public void requestPreviewFrame(Handler handler, int message) {
+    public void requestPreviewFrame(WeakReference<Handler> handler, int message) {
         Camera theCamera = camera;
         if (theCamera != null && previewing) {
             previewCallback.setHandler(handler, message);

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/PreviewCallback.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/PreviewCallback.java
@@ -23,11 +23,13 @@ import android.util.Log;
 
 import com.journeyapps.barcodescanner.Size;
 
+import java.lang.ref.WeakReference;
+
 final class PreviewCallback implements Camera.PreviewCallback {
 
     private static final String TAG = PreviewCallback.class.getSimpleName();
 
-    private Handler previewHandler;
+    private WeakReference<Handler> previewHandler;
     private int previewMessage;
 
     private Size resolution;
@@ -39,7 +41,7 @@ final class PreviewCallback implements Camera.PreviewCallback {
         this.resolution = resolution;
     }
 
-    public void setHandler(Handler previewHandler, int previewMessage) {
+    public void setHandler(WeakReference<Handler> previewHandler, int previewMessage) {
         this.previewHandler = previewHandler;
         this.previewMessage = previewMessage;
     }
@@ -47,12 +49,11 @@ final class PreviewCallback implements Camera.PreviewCallback {
     @Override
     public void onPreviewFrame(byte[] data, Camera camera) {
         Size cameraResolution = resolution;
-        Handler thePreviewHandler = previewHandler;
+        Handler thePreviewHandler = previewHandler.get();
         if (cameraResolution != null && thePreviewHandler != null) {
             Message message = thePreviewHandler.obtainMessage(previewMessage, cameraResolution.width,
                     cameraResolution.height, data);
             message.sendToTarget();
-            previewHandler = null;
         } else {
             Log.d(TAG, "Got preview callback, but no handler or resolution available");
         }


### PR DESCRIPTION
Fix of error after BarcodeView.StopDecoding without pause() CameraPreview. Also, error after decodeSingle() in same condition. How to test:  Modify CustomCaptureActivity like this:
  public void pause(View view) {
    //barcodeView.pause();
    barcodeView.stopDecoding();
  }

  public void resume(View view) {
    //barcodeView.resume();
    barcodeView.decodeSingle(callback);
  }
Then try use buttons PAUSE and RESUME.

stacktrace:
    java.lang.IllegalStateException: Handler (android.os.Handler) {3e5e359} sending message to a Handler on a dead thread
            at android.os.MessageQueue.enqueueMessage(MessageQueue.java:325)
            at android.os.Handler.enqueueMessage(Handler.java:631)
            at android.os.Handler.sendMessageAtTime(Handler.java:600)
            at android.os.Handler.sendMessageDelayed(Handler.java:570)
            at android.os.Handler.sendMessage(Handler.java:507)
            at android.os.Message.sendToTarget(Message.java:416)
            at com.journeyapps.barcodescanner.camera.PreviewCallback.onPreviewFrame(PreviewCallback.java:54)
            at android.hardware.Camera$EventHandler.handleMessage(Camera.java:1112)
            at android.os.Handler.dispatchMessage(Handler.java:102)
            at android.os.Looper.loop(Looper.java:135)
            at android.os.HandlerThread.run(HandlerThread.java:61)