### PR TITLE
Fix memory leak in RotationListener.

### DIFF
--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -24,4 +24,10 @@ dependencies {
     //   compile 'com.google.zxing:core:3.2.0'
     compile(project(':zxing-android-embedded')) { transitive = true }
     compile 'com.android.support:appcompat-v7:22.0.0'
+
+
+    // For development purposes only
+    // https://github.com/square/leakcanary
+    debugCompile 'com.squareup.leakcanary:leakcanary-android:1.3.1'
+    releaseCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.3.1'
 }

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -5,7 +5,8 @@
     <application
         android:allowBackup="true"
         android:icon="@drawable/icon"
-        android:label="@string/app_name" >
+        android:label="@string/app_name"
+        android:name=".SampleApplication">
         <activity
             android:name="example.zxing.MainActivity"
             android:label="@string/app_name"

--- a/sample/src/main/java/example/zxing/SampleApplication.java
+++ b/sample/src/main/java/example/zxing/SampleApplication.java
@@ -1,0 +1,16 @@
+package example.zxing;
+
+import android.app.Application;
+
+import com.squareup.leakcanary.LeakCanary;
+
+/**
+ *
+ */
+public class SampleApplication extends Application {
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        LeakCanary.install(this);
+    }
+}

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/RotationCallback.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/RotationCallback.java
@@ -1,0 +1,13 @@
+package com.journeyapps.barcodescanner;
+
+/**
+ *
+ */
+public interface RotationCallback {
+    /**
+     * Rotation changed.
+     *
+     * @param rotation the current value of windowManager.getDefaultDisplay().getRotation()
+     */
+    void onRotationChanged(int rotation);
+}


### PR DESCRIPTION
Fixes #50.

Did not happen on all devices - could be an Android framework bug.

Can reproduce the leak with LeakCanary on API v17 ARM emulator in sample app:
1. Open CaptureActivity to scan barcode.
2. Leave open for a minute or two.
3. Close the activity.

This works around the leak by removing the reference to the BarcodeView and Activity. This may not be a complete fix, but at least removes the most significant side effects.
