### PR TITLE
Add option to return the captured barcode image

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ integrator.setDesiredBarcodeFormats(IntentIntegrator.ONE_D_CODE_TYPES);
 integrator.setPrompt("Scan a barcode");
 integrator.setCameraId(0);  // Use a specific camera of the device
 integrator.setBeepEnabled(false);
+integrator.setBarcodeImageEnabled(true);
 integrator.initiateScan();
 ```
 

--- a/zxing-android-embedded/src/com/google/zxing/client/android/Intents.java
+++ b/zxing-android-embedded/src/com/google/zxing/client/android/Intents.java
@@ -98,6 +98,10 @@ public final class Intents {
          */
         public static final String BEEP_ENABLED = "BEEP_ENABLED";
 
+        /**
+         * Set to true to return a path to the barcode's image as it was captured. Defaults to false.
+         */
+        public static final String BARCODE_IMAGE_ENABLED = "BARCODE_IMAGE_ENABLED";
 
         /**
          * Whether or not the orientation should be locked when the activity is first started.
@@ -161,6 +165,15 @@ public final class Intents {
          * Call {@link android.content.Intent#getByteArrayExtra(String)} with these keys.
          */
         public static final String RESULT_BYTE_SEGMENTS_PREFIX = "SCAN_RESULT_BYTE_SEGMENTS_";
+
+        /**
+         * Call {@link android.content.Intent#getStringExtra(String)} with {@link #SCAN_RESULT_IMAGE_PATH}
+         * to get a {@code String} path to a cropped and compressed png file of the barcode's image
+         * as it was displayed. Only available if
+         * {@link com.google.zxing.integration.android.IntentIntegrator#setBarcodeImageEnabled(boolean)}
+         * is called with true.
+         */
+        public static final String RESULT_BARCODE_IMAGE_PATH = "SCAN_RESULT_IMAGE_PATH";
 
         private Scan() {
         }

--- a/zxing-android-embedded/src/com/google/zxing/integration/android/IntentIntegrator.java
+++ b/zxing-android-embedded/src/com/google/zxing/integration/android/IntentIntegrator.java
@@ -176,6 +176,17 @@ public class IntentIntegrator {
     }
 
     /**
+     * Set to true to enable saving the barcode image and sending its path in the result Intent.
+     *
+     * @param enabled true to enable barcode image
+     * @return this
+     */
+    public IntentIntegrator setBarcodeImageEnabled(boolean enabled) {
+        addExtra(Intents.Scan.BARCODE_IMAGE_ENABLED, enabled);
+        return this;
+    }
+
+    /**
      * Set the desired barcode formats to scan.
      *
      * @param desiredBarcodeFormats names of {@code BarcodeFormat}s to scan for
@@ -287,11 +298,13 @@ public class IntentIntegrator {
                 int intentOrientation = intent.getIntExtra(Intents.Scan.RESULT_ORIENTATION, Integer.MIN_VALUE);
                 Integer orientation = intentOrientation == Integer.MIN_VALUE ? null : intentOrientation;
                 String errorCorrectionLevel = intent.getStringExtra(Intents.Scan.RESULT_ERROR_CORRECTION_LEVEL);
+                String barcodeImagePath = intent.getStringExtra(Intents.Scan.RESULT_BARCODE_IMAGE_PATH);
                 return new IntentResult(contents,
                         formatName,
                         rawBytes,
                         orientation,
-                        errorCorrectionLevel);
+                        errorCorrectionLevel,
+                        barcodeImagePath);
             }
             return new IntentResult();
         }

--- a/zxing-android-embedded/src/com/google/zxing/integration/android/IntentResult.java
+++ b/zxing-android-embedded/src/com/google/zxing/integration/android/IntentResult.java
@@ -28,21 +28,24 @@ public final class IntentResult {
     private final byte[] rawBytes;
     private final Integer orientation;
     private final String errorCorrectionLevel;
+    private final String barcodeImagePath;
 
     IntentResult() {
-        this(null, null, null, null, null);
+        this(null, null, null, null, null, null);
     }
 
     IntentResult(String contents,
                  String formatName,
                  byte[] rawBytes,
                  Integer orientation,
-                 String errorCorrectionLevel) {
+                 String errorCorrectionLevel,
+                 String barcodeImagePath) {
         this.contents = contents;
         this.formatName = formatName;
         this.rawBytes = rawBytes;
         this.orientation = orientation;
         this.errorCorrectionLevel = errorCorrectionLevel;
+        this.barcodeImagePath = barcodeImagePath;
     }
 
     /**
@@ -80,15 +83,23 @@ public final class IntentResult {
         return errorCorrectionLevel;
     }
 
+    /**
+     * @return path to a temporary file containing the barcode image, if applicable, or null otherwise
+     */
+    public String getBarcodeImagePath() {
+        return barcodeImagePath;
+    }
+
     @Override
     public String toString() {
-        StringBuilder dialogText = new StringBuilder(100);
+        StringBuilder dialogText = new StringBuilder(120);
         dialogText.append("Format: ").append(formatName).append('\n');
         dialogText.append("Contents: ").append(contents).append('\n');
         int rawBytesLength = rawBytes == null ? 0 : rawBytes.length;
         dialogText.append("Raw bytes: (").append(rawBytesLength).append(" bytes)\n");
         dialogText.append("Orientation: ").append(orientation).append('\n');
         dialogText.append("EC level: ").append(errorCorrectionLevel).append('\n');
+        dialogText.append("Barcode image: ").append(barcodeImagePath).append('\n');
         return dialogText.toString();
     }
 


### PR DESCRIPTION
I needed to get an image of the recognised barcode, so I wrote this PR to do so.

If enabled (this is disabled by default), it saves the ``Bitmap`` returned by ``BarcodeResult.getBitmap()`` as a cache file on the internal storage (which doesn't require any additional permission but can be deleted if the device is low on space) and returns its path in the result ``Intent``.

Please don't hesitate to tell me if I have to change something!