### PR TITLE
Fix camera initialization

### DIFF
--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/CameraPreview.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/CameraPreview.java
@@ -657,7 +657,7 @@ public class CameraPreview extends ViewGroup {
 
 
     private void startCameraPreview(CameraSurface surface) {
-        if (!previewActive) {
+        if (!previewActive && cameraInstance != null) {
             Log.i(TAG, "Starting preview");
             cameraInstance.setSurface(surface);
             cameraInstance.startPreview();

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/CameraManager.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/CameraManager.java
@@ -358,7 +358,7 @@ public final class CameraManager {
         } catch (Exception e) {
             // Failed, use safe mode
             try {
-                setDesiredParameters(false);
+                setDesiredParameters(true);
             } catch (Exception e2) {
                 // Well, darn. Give up
                 Log.w(TAG, "Camera rejected even safe-mode parameters! No configuration");

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/CameraManager.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/CameraManager.java
@@ -138,6 +138,9 @@ public final class CameraManager {
      * Must be called from camera thread.
      */
     public void configure() {
+        if(camera == null) {
+            throw new RuntimeException("Camera not open");
+        }
         setParameters();
     }
 

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/CameraThread.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/CameraThread.java
@@ -67,7 +67,6 @@ class CameraThread {
                 if (openCount <= 0) {
                     throw new IllegalStateException("CameraThread is not open");
                 }
-                Log.i(TAG, "Starting new camera thread");
                 this.thread = new HandlerThread("CameraThread");
                 this.thread.start();
                 this.handler = new Handler(thread.getLooper());

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/CameraThread.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/CameraThread.java
@@ -33,7 +33,7 @@ class CameraThread {
     }
 
     /**
-     * Call from main thread.
+     * Call from main thread or camera thread.
      *
      * Enqueues a task on the camera thread.
      *
@@ -41,15 +41,37 @@ class CameraThread {
      */
     protected void enqueue(Runnable runnable) {
         synchronized (LOCK) {
+            checkRunning();
+            this.handler.post(runnable);
+        }
+    }
+
+    /**
+     * Call from main thread or camera thread.
+     *
+     * Enqueues a task on the camera thread.
+     *
+     * @param runnable the task to enqueue
+     * @param delayMillis the delay in milliseconds before executing the runnable
+     */
+    protected void enqueueDelayed(Runnable runnable, long delayMillis) {
+        synchronized (LOCK) {
+            checkRunning();
+            this.handler.postDelayed(runnable, delayMillis);
+        }
+    }
+
+    private void checkRunning() {
+        synchronized (LOCK) {
             if (this.handler == null) {
                 if (openCount <= 0) {
                     throw new IllegalStateException("CameraThread is not open");
                 }
+                Log.i(TAG, "Starting new camera thread");
                 this.thread = new HandlerThread("CameraThread");
                 this.thread.start();
                 this.handler = new Handler(thread.getLooper());
             }
-            this.handler.post(runnable);
         }
     }
 


### PR DESCRIPTION
This prevents the orientation change detection from kicking in too early, sometimes causing the camera to be re-initialized twice on orientation change.

Also add some null checks.

This should fix #108.