### PR TITLE
New preview scaling logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,6 @@ android:
     - 'android-sdk-license-.+'
     - 'google-gdk-license-.+'
 script:
+    # build includes lint and test
     - TERM=dumb ./gradlew build
 

--- a/EMBEDDING.md
+++ b/EMBEDDING.md
@@ -1,0 +1,69 @@
+## Embedding BarcodeView
+
+For more control over the UI or scanning behaviour, some components may be used directly:
+
+* BarcodeView: Handles displaying the preview and decoding of the barcodes.
+* CompoundBarcodeView: Combines BarcodeView with a viewfinder for feedback, as well as some status /
+  prompt text.
+* CaptureManager: Manages the InactivityTimer, BeepManager, orientation lock, and returning of the
+  barcode result.
+
+These components can be used from any Activity or Fragment.
+
+Samples:
+* [ContinuousCaptureActivity][6]: continuously scan and display results (instead of a once-off scan).
+* [ToolbarCaptureActivity][8]: Same as the normal CaptureActivity, but with a Lollipop Toolbar.
+
+
+## Notes on scaling
+
+On each Android device, the camera has a set list of available preview sizes. When embedding the
+barcode scanning along with other components on an Activity, there will almost never be a preview
+size that matches up exactly, so we have to pick one and scale and/or crop it.
+
+Also affecting this is that either SurfaceView or TextureView can be used to display the preview.
+SurfaceView has better performance, but does not support cropping. TextureView is more powerful,
+but has some performance overhead, and is only supported on Android API 14+. We use SurfaceView by
+default.
+
+To avoid aspect ratio distortion, we can crop the preview. However, in some combinations of
+SurfaceView and other components, the camera preview may end up displaying outside the SurfaceView,
+and over other components. This happens especially when:
+
+1. Placing the scanner inside a dialog, or:
+2. Other components are placed before the (Compound)BarcodeView, resulting in a lower z-order.
+
+For these cases we have two solutions:
+
+1. Use TextureView instead of SurfaceView. This may have a performance impact, but solves the above
+   issues. Note that this is only available with Android API 14+.
+
+2. Use either `fitCenter` or `fitXY` for scaling, instead of `centerCrop`. Note that `fitCenter` may
+   result in black bars next to the preview, and `fitXY` may distort the aspect ratio.
+   
+The default is to:
+
+1. Use TextureView on Android API 14+, SurfaceView on lower versions.
+2. Use `centerCrop` scaling when TextureView is used.
+3. Use `fitCenter` if SurfaceView is used.
+
+You can override these options:
+
+```xml
+<com.journeyapps.barcodescanner.CompoundBarcodeView
+        android:layout_width="..."
+        android:layout_height="..."
+        app:zxing_use_texture_view="false" (defaults to true, only has an effect on Android API 14+)
+        app:zxing_preview_scaling_strategy="centerCrop"/> (or fitCenter / fitXY)
+```
+
+For a full-screen barcode scanner with no Toolbar, the recommended options are:
+
+```
+app:zxing_use_texture_view="false"
+app:zxing_preview_scaling_strategy="centerCrop"
+```
+
+
+[8]: sample/src/main/java/example/zxing/ToolbarCaptureActivity.java
+[6]: sample/src/main/java/example/zxing/ContinuousCaptureActivity.java

--- a/README.md
+++ b/README.md
@@ -103,21 +103,10 @@ The previous API for `integrator.setOrientation()` was removed. It caused the Ac
 in landscape orientation, then destroyed and re-created in the requested orientation, which creates
 a bad user experience. The only way around this is to specify the orientation in the manifest.
 
-### Customization
+### Customization and advanced options
 
-For more control over the UI or scanning behaviour, some components may be used directly:
+See [EMBEDDING](EMBEDDING.md).
 
-* BarcodeView: Handles displaying the preview and decoding of the barcodes.
-* CompoundBarcodeView: Combines BarcodeView with a viewfinder for feedback, as well as some status /
-  prompt text.
-* CaptureManager: Manages the InactivityTimer, BeepManager, orientation lock, and returning of the
-  barcode result.
-
-These components can be used from any Activity.
-
-Samples:
-* [ContinuousCaptureActivity][6]: continuously scan and display results (instead of a once-off scan).
-* [ToolbarCaptureActivity][8]: Same as the normal CaptureActivity, but with a Lollipop Toolbar.
 
 ## Android Permissions
 
@@ -157,6 +146,4 @@ You can then use your local version by specifying in your `build.gradle` file:
 [3]: https://github.com/zxing/zxing/wiki/Scanning-Via-Intent
 [4]: https://github.com/journeyapps/zxing-android-embedded/blob/2.x/README.md
 [5]: zxing-android-embedded/src/com/google/zxing/integration/android/IntentIntegrator.java
-[6]: sample/src/main/java/example/zxing/ContinuousCaptureActivity.java
 [7]: http://www.apache.org/licenses/LICENSE-2.0
-[8]: sample/src/main/java/example/zxing/ToolbarCaptureActivity.java

--- a/sample/src/main/res/layout/capture_small.xml
+++ b/sample/src/main/res/layout/capture_small.xml
@@ -30,6 +30,6 @@
         android:layout_marginBottom="150dp"
         android:id="@+id/zxing_barcode_scanner"
         app:zxing_use_texture_view="false"
-        app:zxing_preview_scaling_strategy="fitXY"/>
+        app:zxing_preview_scaling_strategy="centerCrop"/>
 
 </FrameLayout>

--- a/sample/src/main/res/layout/capture_small.xml
+++ b/sample/src/main/res/layout/capture_small.xml
@@ -29,6 +29,7 @@
         android:layout_marginTop="150dp"
         android:layout_marginBottom="150dp"
         android:id="@+id/zxing_barcode_scanner"
-        app:zxing_use_texture_view="true"/>
+        app:zxing_use_texture_view="false"
+        app:zxing_preview_scaling_strategy="fitXY"/>
 
 </FrameLayout>

--- a/zxing-android-embedded/build.gradle
+++ b/zxing-android-embedded/build.gradle
@@ -9,6 +9,9 @@ dependencies {
     compile project.zxingCore
 
     compile 'com.android.support:support-v4:23.1.0'
+
+    testCompile 'junit:junit:4.12'
+    testCompile "org.mockito:mockito-core:1.9.5"
 }
 
 
@@ -20,10 +23,11 @@ android {
     sourceSets {
         main {
             manifest.srcFile 'AndroidManifest.xml'
-            java.srcDirs = ['src-orig', 'src']
+            java.srcDirs = ['src']
             res.srcDirs = ['res-orig', 'res']
             assets.srcDirs = ['assets']
         }
+        test.setRoot('test');
     }
 
     // This is bad practice - we should fix the warnings instead.
@@ -36,6 +40,11 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
+    }
+
+    testOptions {
+        // We test with primitives such as Rect, and rely on their default behaviour working.
+        unitTests.returnDefaultValues = true
     }
 }
 

--- a/zxing-android-embedded/res/layout/zxing_capture.xml
+++ b/zxing-android-embedded/res/layout/zxing_capture.xml
@@ -15,11 +15,17 @@
  limitations under the License.
  -->
 <merge xmlns:android="http://schemas.android.com/apk/res/android"
-       xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
+    <!--
+    This Activity is typically full-screen. Therefore we can safely use centerCrop scaling with
+    a SurfaceView, without fear of weird artifacts. -->
     <com.journeyapps.barcodescanner.CompoundBarcodeView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:id="@+id/zxing_barcode_scanner"/>
+        android:id="@+id/zxing_barcode_scanner"
+        app:zxing_preview_scaling_strategy="centerCrop"
+        app:zxing_use_texture_view="false"/>
 
 </merge>

--- a/zxing-android-embedded/res/values/zxing_attrs.xml
+++ b/zxing-android-embedded/res/values/zxing_attrs.xml
@@ -9,6 +9,11 @@
     <attr name="zxing_framing_rect_width" format="dimension" />
     <attr name="zxing_framing_rect_height" format="dimension" />
     <attr name="zxing_use_texture_view" format="boolean" />
+    <attr name="zxing_preview_scaling_strategy" format="enum">
+      <enum name="centerCrop" value="1" />
+      <enum name="fitCenter" value="2" />
+      <enum name="fitXY" value="3" />
+    </attr>
   </declare-styleable>
 
   <declare-styleable name="zxing_finder">

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/CameraPreview.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/CameraPreview.java
@@ -23,7 +23,10 @@ import com.google.zxing.client.android.R;
 import com.journeyapps.barcodescanner.camera.CameraInstance;
 import com.journeyapps.barcodescanner.camera.CameraSettings;
 import com.journeyapps.barcodescanner.camera.CameraSurface;
+import com.journeyapps.barcodescanner.camera.CenterCropStrategy;
+import com.journeyapps.barcodescanner.camera.CenterFitStrategy;
 import com.journeyapps.barcodescanner.camera.DisplayConfiguration;
+import com.journeyapps.barcodescanner.camera.PreviewScalingStrategy;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -373,10 +376,26 @@ public class CameraPreview extends ViewGroup {
         if (cameraInstance != null) {
             if (cameraInstance.getDisplayConfiguration() == null) {
                 displayConfiguration = new DisplayConfiguration(getDisplayRotation(), containerSize);
+                displayConfiguration.setPreviewScalingStrategy(getPreviewScalingStrategy());
                 cameraInstance.setDisplayConfiguration(displayConfiguration);
                 cameraInstance.configureCamera();
             }
         }
+    }
+
+    /**
+     * Override this to specify a different preview scaling strategy
+     */
+    protected PreviewScalingStrategy getPreviewScalingStrategy() {
+        // If we are using SurfaceTexture, it is safe to use centerCrop.
+        // For SurfaceView, it's better to use centerFit, otherwise the preview may overlap to
+        // other views.
+        if(textureView != null) {
+            return new CenterCropStrategy();
+        } else {
+            return new CenterFitStrategy();
+        }
+
     }
 
     private void previewSized(Size size) {

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/CameraPreview.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/CameraPreview.java
@@ -263,7 +263,7 @@ public class CameraPreview extends ViewGroup {
             this.framingRectSize = new Size(framingRectWidth, framingRectHeight);
         }
 
-        this.useTextureView = styledAttributes.getBoolean(R.styleable.zxing_camera_preview_zxing_use_texture_view, false);
+        this.useTextureView = styledAttributes.getBoolean(R.styleable.zxing_camera_preview_zxing_use_texture_view, true);
 
         // See zxing_attrs.xml for the enum values
         int scalingStrategyNumber = (int) styledAttributes.getInteger(R.styleable.zxing_camera_preview_zxing_preview_scaling_strategy, -1);

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/CameraPreview.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/CameraPreview.java
@@ -24,8 +24,9 @@ import com.journeyapps.barcodescanner.camera.CameraInstance;
 import com.journeyapps.barcodescanner.camera.CameraSettings;
 import com.journeyapps.barcodescanner.camera.CameraSurface;
 import com.journeyapps.barcodescanner.camera.CenterCropStrategy;
-import com.journeyapps.barcodescanner.camera.CenterFitStrategy;
+import com.journeyapps.barcodescanner.camera.FitCenterStrategy;
 import com.journeyapps.barcodescanner.camera.DisplayConfiguration;
+import com.journeyapps.barcodescanner.camera.FitXYStrategy;
 import com.journeyapps.barcodescanner.camera.PreviewScalingStrategy;
 
 import java.util.ArrayList;
@@ -124,6 +125,8 @@ public class CameraPreview extends ViewGroup {
     // Fraction of the width / heigth to use as a margin. This fraction is used on each size, so
     // must be smaller than 0.5;
     private double marginFraction = 0.1d;
+
+    private PreviewScalingStrategy previewScalingStrategy = null;
 
     @TargetApi(14)
     private TextureView.SurfaceTextureListener surfaceTextureListener() {
@@ -262,6 +265,16 @@ public class CameraPreview extends ViewGroup {
 
         this.useTextureView = styledAttributes.getBoolean(R.styleable.zxing_camera_preview_zxing_use_texture_view, false);
 
+        // See zxing_attrs.xml for the enum values
+        int scalingStrategyNumber = (int) styledAttributes.getInteger(R.styleable.zxing_camera_preview_zxing_preview_scaling_strategy, -1);
+        if(scalingStrategyNumber == 1) {
+            previewScalingStrategy = new CenterCropStrategy();
+        } else if(scalingStrategyNumber == 2) {
+            previewScalingStrategy = new FitCenterStrategy();
+        } else if(scalingStrategyNumber == 3) {
+            previewScalingStrategy = new FitXYStrategy();
+        }
+
         styledAttributes.recycle();
     }
 
@@ -384,16 +397,29 @@ public class CameraPreview extends ViewGroup {
     }
 
     /**
-     * Override this to specify a different preview scaling strategy
+     * Override the preview scaling strategy.
+     *
+     * @param previewScalingStrategy null for the default
      */
-    protected PreviewScalingStrategy getPreviewScalingStrategy() {
+    public void setPreviewScalingStrategy(PreviewScalingStrategy previewScalingStrategy) {
+        this.previewScalingStrategy = previewScalingStrategy;
+    }
+
+    /**
+     * Override this to specify a different preview scaling strategy.
+     */
+    public PreviewScalingStrategy getPreviewScalingStrategy() {
+        if(previewScalingStrategy != null) {
+            return previewScalingStrategy;
+        }
+
         // If we are using SurfaceTexture, it is safe to use centerCrop.
-        // For SurfaceView, it's better to use centerFit, otherwise the preview may overlap to
+        // For SurfaceView, it's better to use fitCenter, otherwise the preview may overlap to
         // other views.
         if(textureView != null) {
             return new CenterCropStrategy();
         } else {
-            return new CenterFitStrategy();
+            return new FitCenterStrategy();
         }
 
     }

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/CameraPreview.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/CameraPreview.java
@@ -266,7 +266,7 @@ public class CameraPreview extends ViewGroup {
         this.useTextureView = styledAttributes.getBoolean(R.styleable.zxing_camera_preview_zxing_use_texture_view, true);
 
         // See zxing_attrs.xml for the enum values
-        int scalingStrategyNumber = (int) styledAttributes.getInteger(R.styleable.zxing_camera_preview_zxing_preview_scaling_strategy, -1);
+        int scalingStrategyNumber = styledAttributes.getInteger(R.styleable.zxing_camera_preview_zxing_preview_scaling_strategy, -1);
         if(scalingStrategyNumber == 1) {
             previewScalingStrategy = new CenterCropStrategy();
         } else if(scalingStrategyNumber == 2) {

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/Size.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/Size.java
@@ -34,6 +34,40 @@ public class Size implements Comparable<Size> {
     }
 
     /**
+     * Scales the dimensions so that it fits entirely inside the parent.One of width or height will
+     * fit exactly. Aspect ratio is preserved.
+     *
+     * @param into the parent to fit into
+     * @return the scaled size
+     */
+    public Size scaleFit(Size into) {
+        if(width * into.height >= into.width * height) {
+            // match width
+            return new Size(into.width, height * into.width / width);
+        } else {
+            // match height
+            return new Size(width * into.height / height, into.height);
+        }
+    }
+    /**
+     * Scales the size so that both dimensions will be greater than or equal to the corresponding
+     * dimension of the parent. One of width or height will fit exactly. Aspect ratio is preserved.
+     *
+     * @param into the parent to fit into
+     * @return the scaled size
+     */
+    public Size scaleCrop(Size into) {
+        if(width * into.height <= into.width * height) {
+            // match width
+            return new Size(into.width, height * into.width / width);
+        } else {
+            // match height
+            return new Size(width * into.height / height, into.height);
+        }
+    }
+
+
+    /**
      * Checks if both dimensions of the other size are at least as large as this size.
      *
      * @param other the size to compare with

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/CenterCropStrategy.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/CenterCropStrategy.java
@@ -31,6 +31,9 @@ public class CenterCropStrategy extends PreviewScalingStrategy {
      */
     @Override
     protected float getScore(Size size, Size desired) {
+        if(size.width <= 0 || size.height <= 0) {
+            return 0f;
+        }
         Size scaled = size.scaleCrop(desired);
         // Scaling preserves aspect ratio
         float scaleRatio = scaled.width * 1.0f / size.width;
@@ -39,7 +42,7 @@ public class CenterCropStrategy extends PreviewScalingStrategy {
         float scaleScore;
         if(scaleRatio > 1.0f) {
             // Upscaling
-            scaleScore = 1.0f / scaleRatio * 0.9f;
+            scaleScore = (float)Math.pow(1.0f / scaleRatio, 1.1);
         } else {
             // Downscaling
             scaleScore = scaleRatio;

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/CenterCropStrategy.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/CenterCropStrategy.java
@@ -1,0 +1,115 @@
+package com.journeyapps.barcodescanner.camera;
+
+import android.graphics.Rect;
+import android.util.Log;
+
+import com.journeyapps.barcodescanner.Size;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Scales the dimensions so that it fits entirely inside the parent.One of width or height will
+ * fit exactly. Aspect ratio is preserved.
+ */
+public class CenterCropStrategy implements PreviewScalingStrategy {
+    private static final String TAG = CenterCropStrategy.class.getSimpleName();
+
+
+    /**
+     * Get a score for our size.
+     *
+     * Based on heuristics for penalizing scaling and cropping.
+     *
+     * 1.0 is perfect (exact match).
+     * 0.0 means we can't use it at all.
+     *
+     * @param size the camera preview size (that can be scaled)
+     * @param desired the viewfinder size
+     * @return the score
+     */
+    private float getScore(Size size, Size desired) {
+        Size scaled = size.scaleCrop(desired);
+        // Scaling preserves aspect ratio
+        float scaleRatio = scaled.width * 1.0f / size.width;
+
+        // Treat downscaling as slightly better than upscaling
+        float scaleScore;
+        if(scaleRatio > 1.0f) {
+            // Upscaling
+            scaleScore = 1.0f / scaleRatio * 0.9f;
+        } else {
+            // Downscaling
+            scaleScore = scaleRatio;
+        }
+
+        // Ratio of scaledDimension / dimension.
+        // Note that with scaleCrop, only one dimension is cropped.
+        float cropRatio = scaled.width * 1.0f / desired.width +
+                scaled.height * 1.0f / desired.height;
+
+        // Cropping is bad, square it
+        // 1.0 means no cropping. 50% cropping is 0.44f, 10% cropping is 0.82f
+        float cropScore = 1.0f / cropRatio / cropRatio;
+
+        return scaleScore * cropScore;
+    }
+
+    /**
+     * Choose the best preview size, based on our display size.
+     *
+     * We prefer:
+     * 1. less scaling
+     * 2. less cropping
+     *
+     * @param sizes supported preview sizes, containing at least one size. Sizes are in natural camera orientation.
+     * @param desired The desired display size, in the same orientation
+     * @return the best preview size, never null
+     */
+    public Size getBestPreviewSize(List<Size> sizes, final Size desired) {
+        // Sample of supported preview sizes:
+        // http://www.kirill.org/ar/ar.php
+
+        if (desired == null) {
+            return sizes.get(0);
+        }
+
+        Collections.sort(sizes, new Comparator<Size>() {
+            @Override
+            public int compare(Size a, Size b) {
+                float aScore = getScore(a, desired);
+                float bScore = getScore(b, desired);
+                // Bigger score first
+                return Float.compare(bScore, aScore);
+            }
+        });
+
+        Log.i(TAG, "Viewfinder size: " + desired);
+        Log.i(TAG, "Preview in order of preference: " + sizes);
+
+        return sizes.get(0);
+    }
+
+
+    /**
+     * Scale the preview to cover the viewfinder, then center it.
+     *
+     * Aspect ratio is preserved.
+     *
+     * @param previewSize the size of the preview (camera), in current display orientation
+     * @param viewfinderSize the size of the viewfinder (display), in current display orientation
+     * @return a rect placing the preview
+     */
+    public Rect scalePreview(Size previewSize, Size viewfinderSize) {
+        // We avoid scaling if feasible.
+        Size scaledPreview = previewSize.scaleCrop(viewfinderSize);
+        Log.i(TAG, "Preview: " + previewSize + "; Scaled: " + scaledPreview + "; Want: " + viewfinderSize);
+
+        int dx = (scaledPreview.width - viewfinderSize.width) / 2;
+        int dy = (scaledPreview.height - viewfinderSize.height) / 2;
+
+        return new Rect(-dx, -dy, scaledPreview.width - dx, scaledPreview.height - dy);
+    }
+
+}

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/CenterCropStrategy.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/CenterCropStrategy.java
@@ -13,7 +13,7 @@ import java.util.List;
  * Scales the dimensions so that it fits entirely inside the parent.One of width or height will
  * fit exactly. Aspect ratio is preserved.
  */
-public class CenterCropStrategy implements PreviewScalingStrategy {
+public class CenterCropStrategy extends PreviewScalingStrategy {
     private static final String TAG = CenterCropStrategy.class.getSimpleName();
 
 
@@ -29,7 +29,8 @@ public class CenterCropStrategy implements PreviewScalingStrategy {
      * @param desired the viewfinder size
      * @return the score
      */
-    private float getScore(Size size, Size desired) {
+    @Override
+    protected float getScore(Size size, Size desired) {
         Size scaled = size.scaleCrop(desired);
         // Scaling preserves aspect ratio
         float scaleRatio = scaled.width * 1.0f / size.width;
@@ -55,42 +56,6 @@ public class CenterCropStrategy implements PreviewScalingStrategy {
 
         return scaleScore * cropScore;
     }
-
-    /**
-     * Choose the best preview size, based on our display size.
-     *
-     * We prefer:
-     * 1. less scaling
-     * 2. less cropping
-     *
-     * @param sizes supported preview sizes, containing at least one size. Sizes are in natural camera orientation.
-     * @param desired The desired display size, in the same orientation
-     * @return the best preview size, never null
-     */
-    public Size getBestPreviewSize(List<Size> sizes, final Size desired) {
-        // Sample of supported preview sizes:
-        // http://www.kirill.org/ar/ar.php
-
-        if (desired == null) {
-            return sizes.get(0);
-        }
-
-        Collections.sort(sizes, new Comparator<Size>() {
-            @Override
-            public int compare(Size a, Size b) {
-                float aScore = getScore(a, desired);
-                float bScore = getScore(b, desired);
-                // Bigger score first
-                return Float.compare(bScore, aScore);
-            }
-        });
-
-        Log.i(TAG, "Viewfinder size: " + desired);
-        Log.i(TAG, "Preview in order of preference: " + sizes);
-
-        return sizes.get(0);
-    }
-
 
     /**
      * Scale the preview to cover the viewfinder, then center it.

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/CenterFitStrategy.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/CenterFitStrategy.java
@@ -1,0 +1,115 @@
+package com.journeyapps.barcodescanner.camera;
+
+import android.graphics.Rect;
+import android.util.Log;
+
+import com.journeyapps.barcodescanner.Size;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Scales the size so that both dimensions will be greater than or equal to the corresponding
+ * dimension of the parent. One of width or height will fit exactly. Aspect ratio is preserved.
+ */
+public class CenterFitStrategy implements PreviewScalingStrategy {
+    private static final String TAG = CenterFitStrategy.class.getSimpleName();
+
+
+    /**
+     * Get a score for our size.
+     *
+     * Based on heuristics for penalizing scaling and cropping.
+     *
+     * 1.0 is perfect (exact match).
+     * 0.0 means we can't use it at all.
+     *
+     * @param size the camera preview size (that can be scaled)
+     * @param desired the viewfinder size
+     * @return the score
+     */
+    private float getScore(Size size, Size desired) {
+        Size scaled = size.scaleFit(desired);
+        // Scaling preserves aspect ratio
+        float scaleRatio = scaled.width * 1.0f / size.width;
+
+        // Treat downscaling as slightly better than upscaling
+        float scaleScore;
+        if(scaleRatio > 1.0f) {
+            // Upscaling
+            scaleScore = 1.0f / scaleRatio * 0.9f;
+        } else {
+            // Downscaling
+            scaleScore = scaleRatio;
+        }
+
+        // Ratio of scaledDimension / dimension.
+        // Note that with scaleCrop, only one dimension is cropped.
+        float cropRatio = desired.width * 1.0f / scaled.width +
+                desired.height * 1.0f / scaled.height;
+
+        // Cropping is very bad, since it's used-visible for centerFit
+        // 1.0 means no cropping.
+        float cropScore = 1.0f / cropRatio / cropRatio / cropRatio;
+
+        return scaleScore * cropScore;
+    }
+
+    /**
+     * Choose the best preview size, based on our display size.
+     *
+     * We prefer:
+     * 1. less scaling
+     * 2. less cropping
+     *
+     * @param sizes supported preview sizes, containing at least one size. Sizes are in natural camera orientation.
+     * @param desired The desired display size, in the same orientation
+     * @return the best preview size, never null
+     */
+    public Size getBestPreviewSize(List<Size> sizes, final Size desired) {
+        // Sample of supported preview sizes:
+        // http://www.kirill.org/ar/ar.php
+
+        if (desired == null) {
+            return sizes.get(0);
+        }
+
+        Collections.sort(sizes, new Comparator<Size>() {
+            @Override
+            public int compare(Size a, Size b) {
+                float aScore = getScore(a, desired);
+                float bScore = getScore(b, desired);
+                // Bigger score first
+                return Float.compare(bScore, aScore);
+            }
+        });
+
+        Log.i(TAG, "Viewfinder size: " + desired);
+        Log.i(TAG, "Preview in order of preference: " + sizes);
+
+        return sizes.get(0);
+    }
+
+
+    /**
+     * Scale the preview to cover the viewfinder, then center it.
+     *
+     * Aspect ratio is preserved.
+     *
+     * @param previewSize the size of the preview (camera), in current display orientation
+     * @param viewfinderSize the size of the viewfinder (display), in current display orientation
+     * @return a rect placing the preview
+     */
+    public Rect scalePreview(Size previewSize, Size viewfinderSize) {
+        // We avoid scaling if feasible.
+        Size scaledPreview = previewSize.scaleFit(viewfinderSize);
+        Log.i(TAG, "Preview: " + previewSize + "; Scaled: " + scaledPreview + "; Want: " + viewfinderSize);
+
+        int dx = (scaledPreview.width - viewfinderSize.width) / 2;
+        int dy = (scaledPreview.height - viewfinderSize.height) / 2;
+
+        return new Rect(-dx, -dy, scaledPreview.width - dx, scaledPreview.height - dy);
+    }
+
+}

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/DisplayConfiguration.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/DisplayConfiguration.java
@@ -15,7 +15,7 @@ public class DisplayConfiguration {
     private Size viewfinderSize;
     private int rotation;
     private boolean center = false;
-    private PreviewScalingStrategy previewScalingStrategy = new CenterFitStrategy();
+    private PreviewScalingStrategy previewScalingStrategy = new FitCenterStrategy();
 
     public DisplayConfiguration(int rotation) {
         this.rotation = rotation;

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/FitCenterStrategy.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/FitCenterStrategy.java
@@ -1,0 +1,115 @@
+package com.journeyapps.barcodescanner.camera;
+
+import android.graphics.Rect;
+import android.util.Log;
+
+import com.journeyapps.barcodescanner.Size;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Scales the size so that both dimensions will be greater than or equal to the corresponding
+ * dimension of the parent. One of width or height will fit exactly. Aspect ratio is preserved.
+ */
+public class FitCenterStrategy implements PreviewScalingStrategy {
+    private static final String TAG = FitCenterStrategy.class.getSimpleName();
+
+
+    /**
+     * Get a score for our size.
+     *
+     * Based on heuristics for penalizing scaling and cropping.
+     *
+     * 1.0 is perfect (exact match).
+     * 0.0 means we can't use it at all.
+     *
+     * @param size the camera preview size (that can be scaled)
+     * @param desired the viewfinder size
+     * @return the score
+     */
+    private float getScore(Size size, Size desired) {
+        Size scaled = size.scaleFit(desired);
+        // Scaling preserves aspect ratio
+        float scaleRatio = scaled.width * 1.0f / size.width;
+
+        // Treat downscaling as slightly better than upscaling
+        float scaleScore;
+        if(scaleRatio > 1.0f) {
+            // Upscaling
+            scaleScore = 1.0f / scaleRatio * 0.9f;
+        } else {
+            // Downscaling
+            scaleScore = scaleRatio;
+        }
+
+        // Ratio of scaledDimension / dimension.
+        // Note that with scaleCrop, only one dimension is cropped.
+        float cropRatio = desired.width * 1.0f / scaled.width +
+                desired.height * 1.0f / scaled.height;
+
+        // Cropping is very bad, since it's used-visible for centerFit
+        // 1.0 means no cropping.
+        float cropScore = 1.0f / cropRatio / cropRatio / cropRatio;
+
+        return scaleScore * cropScore;
+    }
+
+    /**
+     * Choose the best preview size, based on our display size.
+     *
+     * We prefer:
+     * 1. less scaling
+     * 2. less cropping
+     *
+     * @param sizes supported preview sizes, containing at least one size. Sizes are in natural camera orientation.
+     * @param desired The desired display size, in the same orientation
+     * @return the best preview size, never null
+     */
+    public Size getBestPreviewSize(List<Size> sizes, final Size desired) {
+        // Sample of supported preview sizes:
+        // http://www.kirill.org/ar/ar.php
+
+        if (desired == null) {
+            return sizes.get(0);
+        }
+
+        Collections.sort(sizes, new Comparator<Size>() {
+            @Override
+            public int compare(Size a, Size b) {
+                float aScore = getScore(a, desired);
+                float bScore = getScore(b, desired);
+                // Bigger score first
+                return Float.compare(bScore, aScore);
+            }
+        });
+
+        Log.i(TAG, "Viewfinder size: " + desired);
+        Log.i(TAG, "Preview in order of preference: " + sizes);
+
+        return sizes.get(0);
+    }
+
+
+    /**
+     * Scale the preview to cover the viewfinder, then center it.
+     *
+     * Aspect ratio is preserved.
+     *
+     * @param previewSize the size of the preview (camera), in current display orientation
+     * @param viewfinderSize the size of the viewfinder (display), in current display orientation
+     * @return a rect placing the preview
+     */
+    public Rect scalePreview(Size previewSize, Size viewfinderSize) {
+        // We avoid scaling if feasible.
+        Size scaledPreview = previewSize.scaleFit(viewfinderSize);
+        Log.i(TAG, "Preview: " + previewSize + "; Scaled: " + scaledPreview + "; Want: " + viewfinderSize);
+
+        int dx = (scaledPreview.width - viewfinderSize.width) / 2;
+        int dy = (scaledPreview.height - viewfinderSize.height) / 2;
+
+        return new Rect(-dx, -dy, scaledPreview.width - dx, scaledPreview.height - dy);
+    }
+
+}

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/FitCenterStrategy.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/FitCenterStrategy.java
@@ -31,6 +31,9 @@ public class FitCenterStrategy extends PreviewScalingStrategy {
      */
     @Override
     protected float getScore(Size size, Size desired) {
+        if(size.width <= 0 || size.height <= 0) {
+            return 0f;
+        }
         Size scaled = size.scaleFit(desired);
         // Scaling preserves aspect ratio
         float scaleRatio = scaled.width * 1.0f / size.width;
@@ -39,7 +42,7 @@ public class FitCenterStrategy extends PreviewScalingStrategy {
         float scaleScore;
         if(scaleRatio > 1.0f) {
             // Upscaling
-            scaleScore = 1.0f / scaleRatio * 0.9f;
+            scaleScore = (float)Math.pow(1.0f / scaleRatio, 1.1);
         } else {
             // Downscaling
             scaleScore = scaleRatio;
@@ -47,8 +50,8 @@ public class FitCenterStrategy extends PreviewScalingStrategy {
 
         // Ratio of scaledDimension / dimension.
         // Note that with scaleCrop, only one dimension is cropped.
-        float cropRatio = desired.width * 1.0f / scaled.width +
-                desired.height * 1.0f / scaled.height;
+        float cropRatio = (desired.width * 1.0f / scaled.width) *
+                (desired.height * 1.0f / scaled.height);
 
         // Cropping is very bad, since it's used-visible for centerFit
         // 1.0 means no cropping.

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/FitCenterStrategy.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/FitCenterStrategy.java
@@ -13,7 +13,7 @@ import java.util.List;
  * Scales the size so that both dimensions will be greater than or equal to the corresponding
  * dimension of the parent. One of width or height will fit exactly. Aspect ratio is preserved.
  */
-public class FitCenterStrategy implements PreviewScalingStrategy {
+public class FitCenterStrategy extends PreviewScalingStrategy {
     private static final String TAG = FitCenterStrategy.class.getSimpleName();
 
 
@@ -29,7 +29,8 @@ public class FitCenterStrategy implements PreviewScalingStrategy {
      * @param desired the viewfinder size
      * @return the score
      */
-    private float getScore(Size size, Size desired) {
+    @Override
+    protected float getScore(Size size, Size desired) {
         Size scaled = size.scaleFit(desired);
         // Scaling preserves aspect ratio
         float scaleRatio = scaled.width * 1.0f / size.width;
@@ -55,42 +56,6 @@ public class FitCenterStrategy implements PreviewScalingStrategy {
 
         return scaleScore * cropScore;
     }
-
-    /**
-     * Choose the best preview size, based on our display size.
-     *
-     * We prefer:
-     * 1. less scaling
-     * 2. less cropping
-     *
-     * @param sizes supported preview sizes, containing at least one size. Sizes are in natural camera orientation.
-     * @param desired The desired display size, in the same orientation
-     * @return the best preview size, never null
-     */
-    public Size getBestPreviewSize(List<Size> sizes, final Size desired) {
-        // Sample of supported preview sizes:
-        // http://www.kirill.org/ar/ar.php
-
-        if (desired == null) {
-            return sizes.get(0);
-        }
-
-        Collections.sort(sizes, new Comparator<Size>() {
-            @Override
-            public int compare(Size a, Size b) {
-                float aScore = getScore(a, desired);
-                float bScore = getScore(b, desired);
-                // Bigger score first
-                return Float.compare(bScore, aScore);
-            }
-        });
-
-        Log.i(TAG, "Viewfinder size: " + desired);
-        Log.i(TAG, "Preview in order of preference: " + sizes);
-
-        return sizes.get(0);
-    }
-
 
     /**
      * Scale the preview to cover the viewfinder, then center it.

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/FitXYStrategy.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/FitXYStrategy.java
@@ -38,6 +38,9 @@ public class FitXYStrategy extends PreviewScalingStrategy {
      */
     @Override
     protected float getScore(Size size, Size desired) {
+        if(size.width <= 0 || size.height <= 0) {
+            return 0f;
+        }
         float scaleX = absRatio(size.width * 1.0f / desired.width);
         float scaleY = absRatio(size.height * 1.0f / desired.height);
 

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/FitXYStrategy.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/FitXYStrategy.java
@@ -12,7 +12,7 @@ import java.util.List;
 /**
  * Scales the size so that it fits exactly. Aspect ratio is NOT preserved.
  */
-public class FitXYStrategy implements PreviewScalingStrategy {
+public class FitXYStrategy extends PreviewScalingStrategy {
     private static final String TAG = FitXYStrategy.class.getSimpleName();
 
 
@@ -36,7 +36,8 @@ public class FitXYStrategy implements PreviewScalingStrategy {
      * @param desired the viewfinder size
      * @return the score
      */
-    private float getScore(Size size, Size desired) {
+    @Override
+    protected float getScore(Size size, Size desired) {
         float scaleX = absRatio(size.width * 1.0f / desired.width);
         float scaleY = absRatio(size.height * 1.0f / desired.height);
 
@@ -49,42 +50,6 @@ public class FitXYStrategy implements PreviewScalingStrategy {
 
         return scaleScore * distortionScore;
     }
-
-    /**
-     * Choose the best preview size, based on our display size.
-     *
-     * We prefer:
-     * 1. less scaling
-     * 2. less cropping
-     *
-     * @param sizes supported preview sizes, containing at least one size. Sizes are in natural camera orientation.
-     * @param desired The desired display size, in the same orientation
-     * @return the best preview size, never null
-     */
-    public Size getBestPreviewSize(List<Size> sizes, final Size desired) {
-        // Sample of supported preview sizes:
-        // http://www.kirill.org/ar/ar.php
-
-        if (desired == null) {
-            return sizes.get(0);
-        }
-
-        Collections.sort(sizes, new Comparator<Size>() {
-            @Override
-            public int compare(Size a, Size b) {
-                float aScore = getScore(a, desired);
-                float bScore = getScore(b, desired);
-                // Bigger score first
-                return Float.compare(bScore, aScore);
-            }
-        });
-
-        Log.i(TAG, "Viewfinder size: " + desired);
-        Log.i(TAG, "Preview in order of preference: " + sizes);
-
-        return sizes.get(0);
-    }
-
 
     /**
      * Scale the preview to match the viewfinder exactly.

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/LegacyPreviewScalingStrategy.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/LegacyPreviewScalingStrategy.java
@@ -12,7 +12,7 @@ import java.util.List;
 /**
  *
  */
-public class LegacyPreviewScalingStrategy implements PreviewScalingStrategy {
+public class LegacyPreviewScalingStrategy extends PreviewScalingStrategy {
     private static final String TAG = LegacyPreviewScalingStrategy.class.getSimpleName();
 
     /**

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/LegacyPreviewScalingStrategy.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/LegacyPreviewScalingStrategy.java
@@ -1,0 +1,158 @@
+package com.journeyapps.barcodescanner.camera;
+
+import android.graphics.Rect;
+import android.util.Log;
+
+import com.journeyapps.barcodescanner.Size;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ *
+ */
+public class LegacyPreviewScalingStrategy implements PreviewScalingStrategy {
+    private static final String TAG = LegacyPreviewScalingStrategy.class.getSimpleName();
+
+    /**
+     * Choose the best preview size, based on our display size.
+     *
+     * We prefer:
+     * 1. no scaling
+     * 2. least downscaling
+     * 3. least upscaling
+     *
+     * We do not care much about aspect ratio, since we just crop away extra pixels. We only choose
+     * the size to minimize scaling.
+     *
+     * In the future we may consider choosing the biggest possible preview size, to maximize the
+     * resolution we have for decoding. We need more testing to see whether or not that is feasible.
+     *
+     * @param sizes supported preview sizes, containing at least one size. Sizes are in natural camera orientation.
+     * @param desired The desired display size, in the same orientation
+     * @return the best preview size, never null
+     */
+    public Size getBestPreviewSize(List<Size> sizes, final Size desired) {
+        // Sample of supported preview sizes:
+        // http://www.kirill.org/ar/ar.php
+
+        if (desired == null) {
+            return sizes.get(0);
+        }
+
+        Collections.sort(sizes, new Comparator<Size>() {
+            @Override
+            public int compare(Size a, Size b) {
+                Size ascaled = scale(a, desired);
+                int aScale = ascaled.width - a.width;
+                Size bscaled = scale(b, desired);
+                int bScale = bscaled.width - b.width;
+
+                if (aScale == 0 && bScale == 0) {
+                    // Both no scaling, pick the smaller one
+                    return a.compareTo(b);
+                } else if (aScale == 0) {
+                    // No scaling for a; pick a
+                    return -1;
+                } else if (bScale == 0) {
+                    // No scaling for b; pick b
+                    return 1;
+                } else if (aScale < 0 && bScale < 0) {
+                    // Both downscaled. Pick the smaller one (less downscaling).
+                    return a.compareTo(b);
+                } else if (aScale > 0 && bScale > 0) {
+                    // Both upscaled. Pick the larger one (less upscaling).
+                    return -a.compareTo(b);
+                } else if (aScale < 0) {
+                    // a downscaled, b upscaled. Pick a.
+                    return -1;
+                } else {
+                    // a upscaled, b downscaled. Pick b.
+                    return 1;
+                }
+            }
+        });
+
+        Log.i(TAG, "Viewfinder size: " + desired);
+        Log.i(TAG, "Preview in order of preference: " + sizes);
+
+        return sizes.get(0);
+    }
+
+
+
+    /**
+     * Scale from so that to.fitsIn(size). Tries to scale by powers of two, or by 3/2. Aspect ratio
+     * is preserved.
+     *
+     * These scaling factors will theoretically result in fast scaling with minimal quality loss.
+     *
+     * TODO: confirm whether or not this is the case in practice.
+     *
+     * @param from the start size
+     * @param to   the minimum desired size
+     * @return the scaled size
+     */
+    public static Size scale(Size from, Size to) {
+        Size current = from;
+
+        if (!to.fitsIn(current)) {
+            // Scale up
+            while (true) {
+                Size scaled150 = current.scale(3, 2);
+                Size scaled200 = current.scale(2, 1);
+                if (to.fitsIn(scaled150)) {
+                    // Scale by 3/2
+                    return scaled150;
+                } else if (to.fitsIn(scaled200)) {
+                    // Scale by 2/1
+                    return scaled200;
+                } else {
+                    // Scale by 2/1 and continue
+                    current = scaled200;
+                }
+            }
+        } else {
+            // Scale down
+            while (true) {
+                Size scaled66 = current.scale(2, 3);
+                Size scaled50 = current.scale(1, 2);
+
+                if (!to.fitsIn(scaled50)) {
+                    if (to.fitsIn(scaled66)) {
+                        // Scale by 2/3
+                        return scaled66;
+                    } else {
+                        // No more downscaling
+                        return current;
+                    }
+                } else {
+                    // Scale by 1/2
+                    current = scaled50;
+                }
+            }
+        }
+    }
+
+    /**
+     * Scale the preview to cover the viewfinder, then center it.
+     *
+     * Aspect ratio is preserved.
+     *
+     * @param previewSize the size of the preview (camera), in current display orientation
+     * @param viewfinderSize the size of the viewfinder (display), in current display orientation
+     * @return a rect placing the preview
+     */
+    public Rect scalePreview(Size previewSize, Size viewfinderSize) {
+        // We avoid scaling if feasible.
+        Size scaledPreview = scale(previewSize, viewfinderSize);
+        Log.i(TAG, "Preview: " + previewSize + "; Scaled: " + scaledPreview + "; Want: " + viewfinderSize);
+
+        int dx = (scaledPreview.width - viewfinderSize.width) / 2;
+        int dy = (scaledPreview.height - viewfinderSize.height) / 2;
+
+        return new Rect(-dx, -dy, scaledPreview.width - dx, scaledPreview.height - dy);
+    }
+
+}

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/PreviewScalingStrategy.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/PreviewScalingStrategy.java
@@ -21,6 +21,8 @@ public abstract class PreviewScalingStrategy {
      * The default implementation lets subclasses calculate a score for each size, the picks the one
      * with the best score.
      *
+     * The sizes list may be reordered by this call.
+     *
      * @param sizes supported preview sizes, containing at least one size. Sizes are in natural camera orientation.
      * @param desired The desired viewfinder size, in the same orientation
      * @return the best preview size, never null
@@ -29,8 +31,28 @@ public abstract class PreviewScalingStrategy {
         // Sample of supported preview sizes:
         // http://www.kirill.org/ar/ar.php
 
+        List<Size> ordered = getBestPreviewOrder(sizes, desired);
+
+        Log.i(TAG, "Viewfinder size: " + desired);
+        Log.i(TAG, "Preview in order of preference: " + ordered);
+
+        return ordered.get(0);
+    }
+
+    /**
+     * Sort previews based on their suitability.
+     *
+     * In most cases, {@link #getBestPreviewSize(List, Size)} should be used instead.
+     *
+     * The sizes list may be reordered by this call.
+     *
+     * @param sizes supported preview sizes, containing at least one size. Sizes are in natural camera orientation.
+     * @param desired The desired viewfinder size, in the same orientation
+     * @return an ordered list, best preview first
+     */
+    public List<Size> getBestPreviewOrder(List<Size> sizes, final Size desired) {
         if (desired == null) {
-            return sizes.get(0);
+            return sizes;
         }
 
         Collections.sort(sizes, new Comparator<Size>() {
@@ -43,10 +65,8 @@ public abstract class PreviewScalingStrategy {
             }
         });
 
-        Log.i(TAG, "Viewfinder size: " + desired);
-        Log.i(TAG, "Preview in order of preference: " + sizes);
 
-        return sizes.get(0);
+        return sizes;
     }
 
     /**

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/PreviewScalingStrategy.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/PreviewScalingStrategy.java
@@ -1,24 +1,69 @@
 package com.journeyapps.barcodescanner.camera;
 
 import android.graphics.Rect;
+import android.util.Log;
 
 import com.journeyapps.barcodescanner.Size;
 
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 /**
  *
  */
-public interface PreviewScalingStrategy {
+public abstract class PreviewScalingStrategy {
+    private static final String TAG = PreviewScalingStrategy.class.getSimpleName();
 
     /**
      * Choose the best preview size, based on our viewfinder size.
+     *
+     * The default implementation lets subclasses calculate a score for each size, the picks the one
+     * with the best score.
      *
      * @param sizes supported preview sizes, containing at least one size. Sizes are in natural camera orientation.
      * @param desired The desired viewfinder size, in the same orientation
      * @return the best preview size, never null
      */
-    Size getBestPreviewSize(List<Size> sizes, final Size desired);
+    public Size getBestPreviewSize(List<Size> sizes, final Size desired) {
+        // Sample of supported preview sizes:
+        // http://www.kirill.org/ar/ar.php
+
+        if (desired == null) {
+            return sizes.get(0);
+        }
+
+        Collections.sort(sizes, new Comparator<Size>() {
+            @Override
+            public int compare(Size a, Size b) {
+                float aScore = getScore(a, desired);
+                float bScore = getScore(b, desired);
+                // Bigger score first
+                return Float.compare(bScore, aScore);
+            }
+        });
+
+        Log.i(TAG, "Viewfinder size: " + desired);
+        Log.i(TAG, "Preview in order of preference: " + sizes);
+
+        return sizes.get(0);
+    }
+
+    /**
+     * Get a score for our size.
+     *
+     * 1.0 is perfect (exact match).
+     * 0.0 means we can't use it at all.
+     *
+     * Subclasses should override this.
+     *
+     * @param size the camera preview size (that can be scaled)
+     * @param desired the viewfinder size
+     * @return the score
+     */
+    protected float getScore(Size size, Size desired) {
+        return 0.5f;
+    }
 
 
     /**
@@ -28,5 +73,5 @@ public interface PreviewScalingStrategy {
      * @param viewfinderSize the size of the viewfinder (display), in current display orientation
      * @return a rect placing the preview, relative to the viewfinder
      */
-    Rect scalePreview(Size previewSize, Size viewfinderSize);
+    public abstract Rect scalePreview(Size previewSize, Size viewfinderSize);
 }

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/PreviewScalingStrategy.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/PreviewScalingStrategy.java
@@ -1,0 +1,32 @@
+package com.journeyapps.barcodescanner.camera;
+
+import android.graphics.Rect;
+
+import com.journeyapps.barcodescanner.Size;
+
+import java.util.List;
+
+/**
+ *
+ */
+public interface PreviewScalingStrategy {
+
+    /**
+     * Choose the best preview size, based on our viewfinder size.
+     *
+     * @param sizes supported preview sizes, containing at least one size. Sizes are in natural camera orientation.
+     * @param desired The desired viewfinder size, in the same orientation
+     * @return the best preview size, never null
+     */
+    Size getBestPreviewSize(List<Size> sizes, final Size desired);
+
+
+    /**
+     * Scale and position the preview relative to the viewfinder.
+     *
+     * @param previewSize the size of the preview (camera), in current display orientation
+     * @param viewfinderSize the size of the viewfinder (display), in current display orientation
+     * @return a rect placing the preview, relative to the viewfinder
+     */
+    Rect scalePreview(Size previewSize, Size viewfinderSize);
+}

--- a/zxing-android-embedded/test/java/com/journeyapps/barcodescanner/SizeTest.java
+++ b/zxing-android-embedded/test/java/com/journeyapps/barcodescanner/SizeTest.java
@@ -1,0 +1,68 @@
+package com.journeyapps.barcodescanner;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ *
+ */
+public class SizeTest {
+
+    @Test
+    public void testScale() {
+        Size a = new Size(12, 9);
+        Size scaled = a.scale(2, 3);
+
+        assertEquals(8, scaled.width);
+        assertEquals(6, scaled.height);
+
+        assertEquals(12, a.width);
+        assertEquals(9, a.height);
+
+    }
+
+    @Test
+    public void testFitsIn() {
+        Size a = new Size(12, 9);
+        assertTrue(a.fitsIn(a));
+        assertTrue(a.fitsIn(new Size(13, 10)));
+        assertTrue(a.fitsIn(new Size(13, 9)));
+        assertTrue(a.fitsIn(new Size(12, 10)));
+        assertFalse(a.fitsIn(new Size(120, 8)));
+        assertFalse(a.fitsIn(new Size(11, 900)));
+    }
+
+    @Test
+    public void testCompare() {
+        Size a = new Size(12, 9);
+        assertEquals(0, a.compareTo(new Size(12, 9)));
+        assertEquals(0, a.compareTo(new Size(9, 12)));
+        assertEquals(-1, a.compareTo(new Size(10, 11)));
+        assertEquals(1, a.compareTo(new Size(10, 10)));
+    }
+
+    @Test
+    public void testRotate() {
+        Size a = new Size(12, 9);
+        assertEquals(new Size(9, 12), a.rotate());
+    }
+
+    @Test
+    public void testScaleCrop() {
+        Size a = new Size(12, 9);
+        assertEquals(new Size(120, 90), a.scaleCrop(new Size(120, 90)));
+        assertEquals(new Size(120, 90), a.scaleCrop(new Size(120, 80)));
+        assertEquals(new Size(120, 90), a.scaleCrop(new Size(110, 90)));
+        assertEquals(new Size(110, 82), a.scaleCrop(new Size(110, 0)));
+    }
+
+    @Test
+    public void testScaleFit() {
+        Size a = new Size(12, 9);
+        assertEquals(new Size(120, 90), a.scaleFit(new Size(120, 90)));
+        assertEquals(new Size(120, 90), a.scaleFit(new Size(120, 100)));
+        assertEquals(new Size(120, 90), a.scaleFit(new Size(130, 90)));
+        assertEquals(new Size(0, 0), a.scaleFit(new Size(110, 0)));
+    }
+}

--- a/zxing-android-embedded/test/java/com/journeyapps/barcodescanner/camera/CenterCropStrategyTest.java
+++ b/zxing-android-embedded/test/java/com/journeyapps/barcodescanner/camera/CenterCropStrategyTest.java
@@ -1,0 +1,29 @@
+package com.journeyapps.barcodescanner.camera;
+
+import com.journeyapps.barcodescanner.Size;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ *
+ */
+public class CenterCropStrategyTest {
+    private final PreviewScalingStrategy strategy = new CenterCropStrategy();
+
+    private Size s(int width, int height) {
+        return new Size(width, height);
+    }
+
+    @Test
+    public void testOrdering() {
+        List<Size> sizes = Arrays.asList(s(30, 40), s(40, 30), s(1000, 1000), s(120, 80), s(120, 90), s(120, 100), s(110, 80), s(120, 20), s(0, 0));
+        List<Size> ordered = strategy.getBestPreviewOrder(sizes, s(120, 90));
+        List<Size> expected = Arrays.asList(s(120, 90), s(120, 100), s(110, 80), s(120, 80), s(40, 30), s(30, 40), s(1000, 1000), s(120, 20), s(0, 0));
+        assertEquals(expected, ordered);
+    }
+}

--- a/zxing-android-embedded/test/java/com/journeyapps/barcodescanner/camera/FitCenterStrategyTest.java
+++ b/zxing-android-embedded/test/java/com/journeyapps/barcodescanner/camera/FitCenterStrategyTest.java
@@ -1,0 +1,30 @@
+package com.journeyapps.barcodescanner.camera;
+
+import com.journeyapps.barcodescanner.Size;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ *
+ */
+public class FitCenterStrategyTest {
+    private final PreviewScalingStrategy strategy = new FitCenterStrategy();
+
+
+    private Size s(int width, int height) {
+        return new Size(width, height);
+    }
+    
+    @Test
+    public void testOrdering() {
+        List<Size> sizes = Arrays.asList(s(30, 40), s(40, 30), s(1000, 1000), s(120, 80), s(120, 90), s(120, 100), s(110, 80), s(120, 20), s(0, 0));
+        List<Size> ordered = strategy.getBestPreviewOrder(sizes, s(120, 90));
+        List<Size> expected = Arrays.asList(s(120, 90), s(110, 80), s(120, 80), s(120, 100), s(40, 30), s(30, 40), s(1000, 1000), s(120, 20), s(0, 0));
+        assertEquals(expected, ordered);
+    }
+}

--- a/zxing-android-embedded/test/java/com/journeyapps/barcodescanner/camera/FitXYStrategyTest.java
+++ b/zxing-android-embedded/test/java/com/journeyapps/barcodescanner/camera/FitXYStrategyTest.java
@@ -1,0 +1,31 @@
+package com.journeyapps.barcodescanner.camera;
+
+import android.graphics.Rect;
+
+import com.journeyapps.barcodescanner.Size;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ *
+ */
+public class FitXYStrategyTest {
+    private final PreviewScalingStrategy strategy = new FitXYStrategy();
+
+    private Size s(int width, int height) {
+        return new Size(width, height);
+    }
+
+    @Test
+    public void testOrdering() {
+        List<Size> sizes = Arrays.asList(s(30, 40), s(40, 30), s(1000, 1000), s(120, 80), s(120, 90), s(120, 100), s(110, 80), s(120, 20), s(0, 0));
+        List<Size> ordered = strategy.getBestPreviewOrder(sizes, s(120, 90));
+        List<Size> expected = Arrays.asList(s(120, 90), s(110, 80), s(120, 100), s(120, 80), s(40, 30), s(30, 40), s(1000, 1000), s(120, 20), s(0, 0));
+        assertEquals(expected, ordered);
+    }
+}


### PR DESCRIPTION
The preview can now be scaled with `fitXY`, `fitCenter`, or `centerCrop`.

For embedded BarcodeView, we now default to using TextureView instead of SurfaceView. For the Intent-based fullscreen CaptureActivity, we still use SurfaceView.

See the docs for more details.