### PR TITLE
lock orientation doesn't work

### DIFF
--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/CaptureManager.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/CaptureManager.java
@@ -152,13 +152,10 @@ public class CaptureManager {
         }
 
         if(intent != null) {
-            if (orientationLock == ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED) {
-                // Only lock the orientation if it's not locked to something else yet
-                boolean orientationLocked = intent.getBooleanExtra(Intents.Scan.ORIENTATION_LOCKED, true);
-
-                if (orientationLocked) {
-                    lockOrientation();
-                }
+            // Only lock the orientation if it's not locked to something else yet
+            boolean orientationLocked = intent.getBooleanExtra(Intents.Scan.ORIENTATION_LOCKED, true);
+            if (orientationLocked) {
+                lockOrientation();
             }
 
             if (Intents.Scan.ACTION.equals(intent.getAction())) {


### PR DESCRIPTION
this if condiction is inside lockOrientation method (right)
with this change, now the orientation will work when set manually.