### PR TITLE
Simplify integration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.journeyapps:zxing-android-embedded:3.3.0@aar'
-    compile 'com.google.zxing:core:3.2.1'
+    compile 'com.journeyapps:zxing-android-embedded:3.3.0'
     compile 'com.android.support:appcompat-v7:23.1.0'   // Version 23+ is required
 }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -46,9 +46,8 @@ android {
 
 dependencies {
     // If you use this from an external project, use the following instead:
-    //   compile 'com.journeyapps:zxing-android-embedded:<version>@aar'
-    //   compile 'com.google.zxing:core:3.2.0'
-    compile(project(':zxing-android-embedded')) { transitive = true }
+    //   compile 'com.journeyapps:zxing-android-embedded:<version>'
+    compile project(':zxing-android-embedded')
     compile 'com.android.support:appcompat-v7:23.1.0'
 
 


### PR DESCRIPTION
The @aar syntax is only required if there also is a jar artifact to
distinguish from. It also has the side-effect to trigger "artifact only"
mode for Gradle, resulting in transitive module dependencies not being
resolved automatically, which was previously worked around by eitehr
specifying "transitive = true" or "com.google.zxing:core:3.2.1" directly.
neitehr is required if we just omit the @aar, which works fine as there is
no competing jar artifact.