### PR TITLE
Request the camera preview on the main ui thread

### DIFF
--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/DecoderThread.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/DecoderThread.java
@@ -125,9 +125,7 @@ public class DecoderThread {
     };
 
     private void requestNextPreview() {
-        if (cameraInstance.isOpen()) {
-            cameraInstance.requestPreview(previewCallback);
-        }
+        cameraInstance.requestPreview(previewCallback);
     }
 
     protected LuminanceSource createSource(SourceData sourceData) {

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/CameraInstance.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/CameraInstance.java
@@ -25,6 +25,7 @@ public class CameraInstance {
     private DisplayConfiguration displayConfiguration;
     private boolean open = false;
     private boolean cameraClosed = true;
+    private Handler mainHandler;
 
     private CameraSettings cameraSettings = new CameraSettings();
 
@@ -41,6 +42,7 @@ public class CameraInstance {
         this.cameraThread = CameraThread.getInstance();
         this.cameraManager = new CameraManager(context);
         this.cameraManager.setCameraSettings(cameraSettings);
+        this.mainHandler = new Handler();
     }
 
     /**
@@ -166,12 +168,20 @@ public class CameraInstance {
     }
 
     public void requestPreview(final PreviewCallback callback) {
-        validateOpen();
-
-        cameraThread.enqueue(new Runnable() {
+        mainHandler.post(new Runnable() {
             @Override
             public void run() {
-                cameraManager.requestPreviewFrame(callback);
+                if(!open) {
+                    Log.d(TAG, "Camera is closed, not requesting preview");
+                    return;
+                }
+
+                cameraThread.enqueue(new Runnable() {
+                    @Override
+                    public void run() {
+                        cameraManager.requestPreviewFrame(callback);
+                    }
+                });
             }
         });
     }


### PR DESCRIPTION
Request the camera preview on the main ui thread, in case the camera instance is being closed at the same time.

Since CameraInstance.close and DecoderThread.requestNextPreview are run in different threads we might, randomly, get to a point where open is still set to true in the isOpen call, while it's false when it reaches the validateOpen call.

This PR fixes this by running the requestPreview code on the main ui thread, making it run in the same thread as the close call will be in.

See #272 for more info.