### PR TITLE
Gradle Update and SDK 27

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.2'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Mar 04 11:52:45 SAST 2018
+#Wed May 30 15:27:56 EDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/sample-nosupport/build.gradle
+++ b/sample-nosupport/build.gradle
@@ -20,5 +20,5 @@ android {
 }
 
 dependencies {
-    compile(project(':zxing-android-embedded')) { transitive = true }
+    implementation(project(':zxing-android-embedded')) { transitive = true }
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -57,12 +57,12 @@ android {
 dependencies {
     // If you use this from an external project, use the following instead:
     //   compile 'com.journeyapps:zxing-android-embedded:<version>'
-    compile project(':zxing-android-embedded')
+    implementation project(':zxing-android-embedded')
 
     // leakcanary is for development purposes only
     // https://github.com/square/leakcanary
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    compile 'com.android.support:support-v13:25.3.1'
-    debugCompile 'com.squareup.leakcanary:leakcanary-android:1.5'
-    releaseCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.5'
+    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation 'com.android.support:support-v13:27.1.1'
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:1.5'
+    releaseImplementation 'com.squareup.leakcanary:leakcanary-android-no-op:1.5'
 }

--- a/zxing-android-embedded/build.gradle
+++ b/zxing-android-embedded/build.gradle
@@ -6,12 +6,12 @@ apply plugin: 'com.jfrog.bintray'
 ext.artifactId = 'zxing-android-embedded'
 
 dependencies {
-    compile project.zxingCore
+    implementation project.zxingCore
 
-    compile 'com.android.support:support-v4:25.3.1'
+    implementation 'com.android.support:support-v4:27.1.1'
 
-    testCompile 'junit:junit:4.12'
-    testCompile "org.mockito:mockito-core:1.9.5"
+    testImplementation 'junit:junit:4.12'
+    testImplementation "org.mockito:mockito-core:1.9.5"
 }
 
 android {


### PR DESCRIPTION
Updated android support dependencies to 27.1.1.

Update deprecated "compile" to "implementation".