### PR TITLE
fix ArithmeticException in CameraPreview

### DIFF
--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/CameraPreview.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/CameraPreview.java
@@ -387,7 +387,17 @@ public class CameraPreview extends ViewGroup {
                 frameInPreview.right * previewWidth / surfaceRect.width(),
                 frameInPreview.bottom * previewHeight / surfaceRect.height());
 
-        if (previewFramingRect.width() <= 0 || previewFramingRect.height() <= 0) {
+        if (surfaceRect.width() != 0 && surfaceRect.height() != 0) {
+            previewFramingRect = new Rect(frameInPreview.left * previewWidth / surfaceRect.width(),
+                    frameInPreview.top * previewHeight / surfaceRect.height(),
+                    frameInPreview.right * previewWidth / surfaceRect.width(),
+                    frameInPreview.bottom * previewHeight / surfaceRect.height());
+
+        } else {
+            previewFramingRect = null;
+        }
+
+        if (previewFramingRect == null || previewFramingRect.width() <= 0 || previewFramingRect.height() <= 0) {
             previewFramingRect = null;
             framingRect = null;
             Log.w(TAG, "Preview frame is too small");


### PR DESCRIPTION
In version 3.6.0 of the lib, we had crashes of ArithmeticException, since we assume that the view has not yet finished drawing and the previewSized method is called

[link Issue #334](https://github.com/journeyapps/zxing-android-embedded/issues/334)
[link Issue #409](https://github.com/journeyapps/zxing-android-embedded/issues/409)