### PR TITLE
Fix preview sizing & fix ResultPoints for front camera

### DIFF
--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/CameraPreview.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/CameraPreview.java
@@ -581,6 +581,10 @@ public class CameraPreview extends ViewGroup {
         return previewFramingRect;
     }
 
+    public Size getPreviewSize() {
+        return previewSize;
+    }
+
     /**
      * @return the CameraSettings currently in use
      */

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/CameraPreview.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/CameraPreview.java
@@ -197,6 +197,8 @@ public class CameraPreview extends ViewGroup {
         @Override
         public boolean handleMessage(Message message) {
             if (message.what == R.id.zxing_prewiew_size_ready) {
+                // At this point, we have the camera preview size, and should have containerSize and
+                // surfaceRect.
                 previewSized((Size) message.obj);
                 return true;
             } else if (message.what == R.id.zxing_camera_error) {
@@ -375,7 +377,13 @@ public class CameraPreview extends ViewGroup {
         int width = containerSize.width;
         int height = containerSize.height;
 
-        surfaceRect = displayConfiguration.scalePreview(previewSize);
+        Rect scaledPreview = displayConfiguration.scalePreview(previewSize);
+        if (scaledPreview.width() <= 0 || scaledPreview.height() <= 0) {
+            // Something is not ready yet - we can't start the preview.
+            return;
+        }
+
+        surfaceRect = scaledPreview;
 
         Rect container = new Rect(0, 0, width, height);
         framingRect = calculateFramingRect(container, surfaceRect);
@@ -386,16 +394,6 @@ public class CameraPreview extends ViewGroup {
                 frameInPreview.top * previewHeight / surfaceRect.height(),
                 frameInPreview.right * previewWidth / surfaceRect.width(),
                 frameInPreview.bottom * previewHeight / surfaceRect.height());
-
-        if (surfaceRect.width() != 0 && surfaceRect.height() != 0) {
-            previewFramingRect = new Rect(frameInPreview.left * previewWidth / surfaceRect.width(),
-                    frameInPreview.top * previewHeight / surfaceRect.height(),
-                    frameInPreview.right * previewWidth / surfaceRect.width(),
-                    frameInPreview.bottom * previewHeight / surfaceRect.height());
-
-        } else {
-            previewFramingRect = null;
-        }
 
         if (previewFramingRect == null || previewFramingRect.width() <= 0 || previewFramingRect.height() <= 0) {
             previewFramingRect = null;

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/DecoderThread.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/DecoderThread.java
@@ -164,8 +164,8 @@ public class DecoderThread {
             }
         }
         if (resultHandler != null) {
-            List<ResultPoint> resultPoints = decoder.getPossibleResultPoints();
-            Message message = Message.obtain(resultHandler, R.id.zxing_possible_result_points, resultPoints);
+            List<ResultPoint> resultPoints = BarcodeResult.transformResultPoints(decoder.getPossibleResultPoints(), sourceData);
+                    Message message = Message.obtain(resultHandler, R.id.zxing_possible_result_points, resultPoints);
             message.sendToTarget();
         }
         requestNextPreview();

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/DecoratedBarcodeView.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/DecoratedBarcodeView.java
@@ -165,6 +165,22 @@ public class DecoratedBarcodeView extends FrameLayout {
         barcodeView.setDecoderFactory(new DefaultDecoderFactory(decodeFormats, decodeHints, characterSet, scanType));
     }
 
+    public void setCameraSettings(CameraSettings cameraSettings) {
+        barcodeView.setCameraSettings(cameraSettings);
+    }
+
+    public void setDecoderFactory(DecoderFactory decoderFactory) {
+        barcodeView.setDecoderFactory(decoderFactory);
+    }
+
+    public DecoderFactory getDecoderFactory() {
+        return barcodeView.getDecoderFactory();
+    }
+
+    public CameraSettings getCameraSettings() {
+        return barcodeView.getCameraSettings();
+    }
+
     public void setStatusText(String text) {
         // statusView is optional when using a custom layout
         if(statusView != null) {

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/RawImageData.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/RawImageData.java
@@ -1,0 +1,142 @@
+package com.journeyapps.barcodescanner;
+
+import android.graphics.Rect;
+
+public class RawImageData {
+    private byte[] data;
+    private int width;
+    private int height;
+
+    public RawImageData(byte[] data, int width, int height) {
+        this.data = data;
+        this.width = width;
+        this.height = height;
+    }
+
+    public byte[] getData() {
+        return data;
+    }
+
+    public int getWidth() {
+        return width;
+    }
+
+    public int getHeight() {
+        return height;
+    }
+
+    public RawImageData cropAndScale(Rect cropRect, int scale) {
+        int width = cropRect.width() / scale;
+        int height = cropRect.height() / scale;
+
+        int top = cropRect.top;
+
+        int area = width * height;
+        byte[] matrix = new byte[area];
+
+        if (scale == 1) {
+            int inputOffset = top * this.width + cropRect.left;
+
+            // Copy one cropped row at a time.
+            for (int y = 0; y < height; y++) {
+                int outputOffset = y * width;
+                System.arraycopy(this.data, inputOffset, matrix, outputOffset, width);
+                inputOffset += this.width;
+            }
+        } else {
+            int inputOffset = top * this.width + cropRect.left;
+
+            // Copy one cropped row at a time.
+            for (int y = 0; y < height; y++) {
+                int outputOffset = y * width;
+                int xOffset = inputOffset;
+                for (int x = 0; x < width; x++) {
+                    matrix[outputOffset] = this.data[xOffset];
+                    xOffset += scale;
+                    outputOffset += 1;
+                }
+                inputOffset += this.width * scale;
+            }
+        }
+        return new RawImageData(matrix, width, height);
+    }
+
+
+    public RawImageData rotateCameraPreview(int cameraRotation) {
+        switch (cameraRotation) {
+            case 90:
+                return new RawImageData(rotateCW(data, this.width, this.height), this.height, this.width);
+            case 180:
+                return new RawImageData(rotate180(data, this.width, this.height), this.width, this.height);
+            case 270:
+                return new RawImageData(rotateCCW(data, this.width, this.height), this.height, this.width);
+            case 0:
+            default:
+                return this;
+        }
+    }
+
+    /**
+     * Rotate an image by 90 degrees CW.
+     *
+     * @param data        the image data, in with the first width * height bytes being the luminance data.
+     * @param imageWidth  the width of the image
+     * @param imageHeight the height of the image
+     * @return the rotated bytes
+     */
+    public static byte[] rotateCW(byte[] data, int imageWidth, int imageHeight) {
+        // Adapted from http://stackoverflow.com/a/15775173
+        // data may contain more than just y (u and v), but we are only interested in the y section.
+
+        byte[] yuv = new byte[imageWidth * imageHeight];
+        int i = 0;
+        for (int x = 0; x < imageWidth; x++) {
+            for (int y = imageHeight - 1; y >= 0; y--) {
+                yuv[i] = data[y * imageWidth + x];
+                i++;
+            }
+        }
+        return yuv;
+    }
+
+    /**
+     * Rotate an image by 180 degrees.
+     *
+     * @param data        the image data, in with the first width * height bytes being the luminance data.
+     * @param imageWidth  the width of the image
+     * @param imageHeight the height of the image
+     * @return the rotated bytes
+     */
+    public static byte[] rotate180(byte[] data, int imageWidth, int imageHeight) {
+        int n = imageWidth * imageHeight;
+        byte[] yuv = new byte[n];
+
+        int i = n - 1;
+        for (int j = 0; j < n; j++) {
+            yuv[i] = data[j];
+            i--;
+        }
+        return yuv;
+    }
+
+    /**
+     * Rotate an image by 90 degrees CCW.
+     *
+     * @param data        the image data, in with the first width * height bytes being the luminance data.
+     * @param imageWidth  the width of the image
+     * @param imageHeight the height of the image
+     * @return the rotated bytes
+     */
+    public static byte[] rotateCCW(byte[] data, int imageWidth, int imageHeight) {
+        int n = imageWidth * imageHeight;
+        byte[] yuv = new byte[n];
+        int i = n - 1;
+        for (int x = 0; x < imageWidth; x++) {
+            for (int y = imageHeight - 1; y >= 0; y--) {
+                yuv[i] = data[y * imageWidth + x];
+                i--;
+            }
+        }
+        return yuv;
+    }
+}

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/ViewfinderView.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/ViewfinderView.java
@@ -59,10 +59,10 @@ public class ViewfinderView extends View {
     protected List<ResultPoint> lastPossibleResultPoints;
     protected CameraPreview cameraPreview;
 
-    // Cache the framingRect and previewFramingRect, so that we can still draw it after the preview
+    // Cache the framingRect and previewSize, so that we can still draw it after the preview
     // stopped.
     protected Rect framingRect;
-    protected Rect previewFramingRect;
+    protected Size previewSize;
 
     // This constructor is used when the class is built from an XML resource.
     public ViewfinderView(Context context, AttributeSet attrs) {
@@ -128,22 +128,22 @@ public class ViewfinderView extends View {
             return;
         }
         Rect framingRect = cameraPreview.getFramingRect();
-        Rect previewFramingRect = cameraPreview.getPreviewFramingRect();
-        if(framingRect != null && previewFramingRect != null) {
+        Size previewSize = cameraPreview.getPreviewSize();
+        if(framingRect != null && previewSize != null) {
             this.framingRect = framingRect;
-            this.previewFramingRect = previewFramingRect;
+            this.previewSize = previewSize;
         }
     }
 
     @Override
     public void onDraw(Canvas canvas) {
         refreshSizes();
-        if (framingRect == null || previewFramingRect == null) {
+        if (framingRect == null || previewSize == null) {
             return;
         }
 
         final Rect frame = framingRect;
-        final Rect previewFrame = previewFramingRect;
+        final Size previewSize = this.previewSize;
 
         final int width = canvas.getWidth();
         final int height = canvas.getHeight();
@@ -168,11 +168,8 @@ public class ViewfinderView extends View {
             final int middle = frame.height() / 2 + frame.top;
             canvas.drawRect(frame.left + 2, middle - 1, frame.right - 1, middle + 2, paint);
 
-            final float scaleX = frame.width() / (float) previewFrame.width();
-            final float scaleY = frame.height() / (float) previewFrame.height();
-
-            final int frameLeft = frame.left;
-            final int frameTop = frame.top;
+            final float scaleX = this.getWidth() / (float) previewSize.width;
+            final float scaleY = this.getHeight() / (float) previewSize.height;
 
             // draw the last possible result points
             if (!lastPossibleResultPoints.isEmpty()) {
@@ -181,8 +178,8 @@ public class ViewfinderView extends View {
                 float radius = POINT_SIZE / 2.0f;
                 for (final ResultPoint point : lastPossibleResultPoints) {
                     canvas.drawCircle(
-                            frameLeft + (int) (point.getX() * scaleX),
-                            frameTop + (int) (point.getY() * scaleY),
+                             (int) (point.getX() * scaleX),
+                             (int) (point.getY() * scaleY),
                             radius, paint
                     );
                 }
@@ -195,8 +192,8 @@ public class ViewfinderView extends View {
                 paint.setColor(resultPointColor);
                 for (final ResultPoint point : possibleResultPoints) {
                     canvas.drawCircle(
-                            frameLeft + (int) (point.getX() * scaleX),
-                            frameTop + (int) (point.getY() * scaleY),
+                            (int) (point.getX() * scaleX),
+                            (int) (point.getY() * scaleY),
                             POINT_SIZE, paint
                     );
                 }

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/CameraManager.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/CameraManager.java
@@ -102,6 +102,10 @@ public final class CameraManager {
                     }
                     int format = camera.getParameters().getPreviewFormat();
                     SourceData source = new SourceData(data, cameraResolution.width, cameraResolution.height, format, getCameraRotation());
+
+                    if (cameraInfo.facing == Camera.CameraInfo.CAMERA_FACING_FRONT) {
+                        source.setPreviewMirrored(true);
+                    }
                     callback.onPreview(source);
                 } catch (RuntimeException e) {
                     // Could be:
@@ -312,7 +316,7 @@ public final class CameraManager {
         if (rawSupportedSizes == null) {
             Camera.Size defaultSize = parameters.getPreviewSize();
             if (defaultSize != null) {
-                // Work around potential platform bugs
+                Size previewSize = new Size(defaultSize.width, defaultSize.height);
                 previewSizes.add(new Size(defaultSize.width, defaultSize.height));
             }
             return previewSizes;


### PR DESCRIPTION
Follow-up to #463 - the rect was still being accessed before the null check.

This also changes ResultPoints to be returned relative to the camera preview, instead of relative to the decode data. This fixes an issue where the points did not match the preview in the case of a front/mirrored camera.

Internally, this now supports down-scaling the image by an integer factor before decoding. This could allow faster decoding in the case of very large image previews. It is only an internal property currently - can't be set yet.
