### PR TITLE
Use default annotation for optional interface method

### DIFF
--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/BarcodeCallback.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/BarcodeCallback.java
@@ -22,7 +22,10 @@ public interface BarcodeCallback {
      *
      * Do not depend on this being called at any specific point in the decode cycle.
      *
+     * This is a default method and can be omitted by the implementing class.
+     *
      * @param resultPoints points potentially identifying a barcode
      */
-    void possibleResultPoints(List<ResultPoint> resultPoints);
+    default void possibleResultPoints(List<ResultPoint> resultPoints) {
+    }
 }


### PR DESCRIPTION
The BarcodeCallback interface has two methods. One of them is the actual callback, the other one is the optional method for result points. From JAVA 8 on we can use default methods to mark optional interface methods.