### PR TITLE
Camera permission behaviour

### DIFF
--- a/sample/src/main/java/example/zxing/CustomScannerActivity.java
+++ b/sample/src/main/java/example/zxing/CustomScannerActivity.java
@@ -8,6 +8,8 @@ import android.view.KeyEvent;
 import android.view.View;
 import android.widget.Button;
 
+import androidx.annotation.NonNull;
+
 import com.journeyapps.barcodescanner.CaptureManager;
 import com.journeyapps.barcodescanner.DecoratedBarcodeView;
 import com.journeyapps.barcodescanner.ViewfinderView;
@@ -45,6 +47,7 @@ public class CustomScannerActivity extends Activity implements
 
         capture = new CaptureManager(this, barcodeScannerView);
         capture.initializeFromIntent(getIntent(), savedInstanceState);
+        capture.setShowMissingCameraPermissionDialog(false);
         capture.decode();
 
         changeMaskColor(null);
@@ -115,5 +118,10 @@ public class CustomScannerActivity extends Activity implements
     @Override
     public void onTorchOff() {
         switchFlashlightButton.setText(R.string.turn_on_flashlight);
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        capture.onRequestPermissionsResult(requestCode, permissions, grantResults);
     }
 }

--- a/sample/src/main/java/example/zxing/MainActivity.java
+++ b/sample/src/main/java/example/zxing/MainActivity.java
@@ -128,8 +128,14 @@ public class MainActivity extends AppCompatActivity {
         IntentResult result = IntentIntegrator.parseActivityResult(resultCode, data);
 
         if(result.getContents() == null) {
-            Log.d("MainActivity", "Cancelled scan");
-            Toast.makeText(this, "Cancelled", Toast.LENGTH_LONG).show();
+            Intent originalIntent = result.getOriginalIntent();
+            if (originalIntent == null) {
+                Log.d("MainActivity", "Cancelled scan");
+                Toast.makeText(this, "Cancelled", Toast.LENGTH_LONG).show();
+            } else if(originalIntent.hasExtra(Intents.Scan.MISSING_CAMERA_PERMISSION)) {
+                Log.d("MainActivity", "Cancelled scan due to missing camera permission");
+                Toast.makeText(this, "Cancelled due to missing camera permission", Toast.LENGTH_LONG).show();
+            }
         } else {
             Log.d("MainActivity", "Scanned");
             Toast.makeText(this, "Scanned: " + result.getContents(), Toast.LENGTH_LONG).show();

--- a/zxing-android-embedded/src/com/google/zxing/client/android/Intents.java
+++ b/zxing-android-embedded/src/com/google/zxing/client/android/Intents.java
@@ -116,6 +116,11 @@ public final class Intents {
         public static final String TIMEOUT = "TIMEOUT";
 
         /**
+         * Set the time to finish the scan screen.
+         */
+        public static final String MISSING_CAMERA_PERMISSION = "MISSING_CAMERA_PERMISSION";
+
+        /**
          * Whether or not the orientation should be locked when the activity is first started.
          * Defaults to true.
          */

--- a/zxing-android-embedded/src/com/google/zxing/client/android/Intents.java
+++ b/zxing-android-embedded/src/com/google/zxing/client/android/Intents.java
@@ -121,6 +121,16 @@ public final class Intents {
         public static final String MISSING_CAMERA_PERMISSION = "MISSING_CAMERA_PERMISSION";
 
         /**
+         * Set the time to finish the scan screen.
+         */
+        public static final String SHOW_MISSING_CAMERA_PERMISSION_DIALOG = "SHOW_MISSING_CAMERA_PERMISSION_DIALOG";
+
+        /**
+         * Set the time to finish the scan screen.
+         */
+        public static final String MISSING_CAMERA_PERMISSION_DIALOG_MESSAGE = "MISSING_CAMERA_PERMISSION_DIALOG_MESSAGE";
+
+        /**
          * Whether or not the orientation should be locked when the activity is first started.
          * Defaults to true.
          */

--- a/zxing-android-embedded/src/com/google/zxing/integration/android/IntentIntegrator.java
+++ b/zxing-android-embedded/src/com/google/zxing/integration/android/IntentIntegrator.java
@@ -383,9 +383,10 @@ public class IntentIntegrator {
                     rawBytes,
                     orientation,
                     errorCorrectionLevel,
-                    barcodeImagePath);
+                    barcodeImagePath,
+                    intent);
         }
-        return new IntentResult();
+        return new IntentResult(intent);
     }
 
     private static List<String> list(String... values) {

--- a/zxing-android-embedded/src/com/google/zxing/integration/android/IntentResult.java
+++ b/zxing-android-embedded/src/com/google/zxing/integration/android/IntentResult.java
@@ -16,6 +16,8 @@
 
 package com.google.zxing.integration.android;
 
+import android.content.Intent;
+
 /**
  * <p>Encapsulates the result of a barcode scan invoked through {@link IntentIntegrator}.</p>
  *
@@ -29,9 +31,14 @@ public final class IntentResult {
     private final Integer orientation;
     private final String errorCorrectionLevel;
     private final String barcodeImagePath;
+    private final Intent originalIntent;
 
     IntentResult() {
-        this(null, null, null, null, null, null);
+        this(null, null, null, null, null, null, null);
+    }
+
+    IntentResult(Intent intent) {
+        this(null, null, null, null, null, null, intent);
     }
 
     IntentResult(String contents,
@@ -39,13 +46,15 @@ public final class IntentResult {
                  byte[] rawBytes,
                  Integer orientation,
                  String errorCorrectionLevel,
-                 String barcodeImagePath) {
+                 String barcodeImagePath,
+                 Intent originalIntent) {
         this.contents = contents;
         this.formatName = formatName;
         this.rawBytes = rawBytes;
         this.orientation = orientation;
         this.errorCorrectionLevel = errorCorrectionLevel;
         this.barcodeImagePath = barcodeImagePath;
+        this.originalIntent = originalIntent;
     }
 
     /**
@@ -90,6 +99,13 @@ public final class IntentResult {
         return barcodeImagePath;
     }
 
+    /**
+     * @return the original intent
+     */
+    public Intent getOriginalIntent() {
+        return originalIntent;
+    }
+
     @Override
     public String toString() {
         int rawBytesLength = rawBytes == null ? 0 : rawBytes.length;
@@ -98,6 +114,7 @@ public final class IntentResult {
             "Raw bytes: (" + rawBytesLength + " bytes)\n" +
             "Orientation: " + orientation + '\n' +
             "EC level: " + errorCorrectionLevel + '\n' +
-            "Barcode image: " + barcodeImagePath + '\n';
+            "Barcode image: " + barcodeImagePath + '\n' +
+            "Original intent: " + originalIntent + '\n';
     }
 }

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/CaptureManager.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/CaptureManager.java
@@ -265,7 +265,7 @@ public class CaptureManager {
      *     which is either {@link android.content.pm.PackageManager#PERMISSION_GRANTED}
      *     or {@link android.content.pm.PackageManager#PERMISSION_DENIED}. Never null.
      */
-    void onRequestPermissionsResult(int requestCode, String permissions[], int[] grantResults) {
+    public void onRequestPermissionsResult(int requestCode, String permissions[], int[] grantResults) {
         if(requestCode == cameraPermissionReqCode) {
             if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                 // permission was granted

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/CaptureManager.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/CaptureManager.java
@@ -239,12 +239,17 @@ public class CaptureManager {
      * Call from Activity#onResume().
      */
     public void onResume() {
-        openCameraWithPermission();
+        if(Build.VERSION.SDK_INT >= 23) {
+            openCameraWithPermission();
+        } else {
+            barcodeView.resume();
+        }
         inactivityTimer.start();
     }
 
     private boolean askedPermission = false;
 
+    @TargetApi(23)
     private void openCameraWithPermission() {
         if (ContextCompat.checkSelfPermission(this.activity, Manifest.permission.CAMERA)
                 == PackageManager.PERMISSION_GRANTED) {

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/CaptureManager.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/CaptureManager.java
@@ -249,9 +249,7 @@ public class CaptureManager {
                     new String[]{Manifest.permission.CAMERA},
                     cameraPermissionReqCode);
             askedPermission = true;
-        } else {
-            // Wait for permission result
-        }
+        } // else wait for permission result
     }
 
     /**

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/CaptureManager.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/CaptureManager.java
@@ -229,17 +229,12 @@ public class CaptureManager {
      * Call from Activity#onResume().
      */
     public void onResume() {
-        if(Build.VERSION.SDK_INT >= 23) {
-            openCameraWithPermission();
-        } else {
-            barcodeView.resume();
-        }
+        openCameraWithPermission();
         inactivityTimer.start();
     }
 
     private boolean askedPermission = false;
 
-    @TargetApi(23)
     private void openCameraWithPermission() {
         if (ContextCompat.checkSelfPermission(this.activity, Manifest.permission.CAMERA)
                 == PackageManager.PERMISSION_GRANTED) {
@@ -260,7 +255,7 @@ public class CaptureManager {
      *     which is either {@link android.content.pm.PackageManager#PERMISSION_GRANTED}
      *     or {@link android.content.pm.PackageManager#PERMISSION_DENIED}. Never null.
      */
-    public void onRequestPermissionsResult(int requestCode, String permissions[], int[] grantResults) {
+    void onRequestPermissionsResult(int requestCode, String permissions[], int[] grantResults) {
         if(requestCode == cameraPermissionReqCode) {
             if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                 // permission was granted

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/CaptureManager.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/CaptureManager.java
@@ -174,6 +174,13 @@ public class CaptureManager {
                 beepManager.setBeepEnabled(false);
             }
 
+            if (intent.hasExtra(Intents.Scan.SHOW_MISSING_CAMERA_PERMISSION_DIALOG)) {
+                setShowMissingCameraPermissionDialog(
+                        intent.getBooleanExtra(Intents.Scan.SHOW_MISSING_CAMERA_PERMISSION_DIALOG, true),
+                        intent.getStringExtra(Intents.Scan.MISSING_CAMERA_PERMISSION_DIALOG_MESSAGE)
+                );
+            }
+
             if (intent.hasExtra(Intents.Scan.TIMEOUT)) {
                 Runnable runnable = new Runnable() {
                     @Override
@@ -437,8 +444,8 @@ public class CaptureManager {
      * In both cases, the activity result is set to {@link Intents.Scan#MISSING_CAMERA_PERMISSION}
      * and cancelled
      */
-    public void setShowDialogIfMissingCameraPermission(boolean visible) {
-        setShowDialogIfMissingCameraPermission(visible, "");
+    public void setShowMissingCameraPermissionDialog(boolean visible) {
+        setShowMissingCameraPermissionDialog(visible, "");
     }
 
     /**
@@ -449,7 +456,7 @@ public class CaptureManager {
      * In both cases, the activity result is set to {@link Intents.Scan#MISSING_CAMERA_PERMISSION}
      * and cancelled
      */
-    public void setShowDialogIfMissingCameraPermission(boolean visible, String message) {
+    public void setShowMissingCameraPermissionDialog(boolean visible, String message) {
         showDialogIfMissingCameraPermission = visible;
         missingCameraPermissionDialogMessage = message != null ? message : "";
     }

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/CaptureManager.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/CaptureManager.java
@@ -1,7 +1,6 @@
 package com.journeyapps.barcodescanner;
 
 import android.Manifest;
-import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
@@ -10,16 +9,16 @@ import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.graphics.Bitmap;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
-import androidx.core.app.ActivityCompat;
-import androidx.core.content.ContextCompat;
 import android.util.Log;
 import android.view.Display;
 import android.view.Surface;
 import android.view.Window;
 import android.view.WindowManager;
+
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
 
 import com.google.zxing.ResultMetadataType;
 import com.google.zxing.ResultPoint;
@@ -60,6 +59,8 @@ public class CaptureManager {
     private int orientationLock = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED;
     private static final String SAVED_ORIENTATION_LOCK = "SAVED_ORIENTATION_LOCK";
     private boolean returnBarcodeImagePath = false;
+
+    private boolean showDialogIfMissingCameraPermission = true;
 
     private boolean destroyed = false;
 
@@ -261,8 +262,10 @@ public class CaptureManager {
                 // permission was granted
                 barcodeView.resume();
             } else {
-                // TODO: display better error message.
-                displayFrameworkBugMessageAndExit();
+                if (showDialogIfMissingCameraPermission) {
+                    // TODO: display better error message.
+                    displayFrameworkBugMessageAndExit();
+                }
             }
         }
     }

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/CaptureManager.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/CaptureManager.java
@@ -1,6 +1,7 @@
 package com.journeyapps.barcodescanner;
 
 import android.Manifest;
+import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Intent;
@@ -8,6 +9,7 @@ import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.graphics.Bitmap;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.util.Log;


### PR DESCRIPTION
Addresses #488

- Important: Old behaviour does not change. If library is used as before, behaviour does not change
- Showing the dialog if permission is missing is optional now but true as default (as before)
- Message can be set optionally, either programmatically or via IntentIntegrator
- New Activity result is set if permission is not granted
- Programmers can react on the onActivityResult Intent and modify if a dialog should be shown by the library directly or not
- Removes SDK 23 version checks since library uses API 24