### PR TITLE
Move CameraConfigurationUtils to prevent clash with other ZXing libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ subprojects {
         mavenLocal()
     }
 
-    version = '4.1.0'
+    version = '4.1.1'
     group = 'com.journeyapps'
 
     ext.androidTargetSdk = 28

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -6,8 +6,8 @@ android {
     defaultConfig {
         minSdkVersion 24
         targetSdkVersion project.androidTargetSdk
-        versionCode 410
-        versionName "4.1.0"
+        versionCode 411
+        versionName "4.1.1"
     }
 
     def validConfig

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/CameraConfigurationUtils.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/CameraConfigurationUtils.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.zxing.client.android.camera;
+package com.journeyapps.barcodescanner.camera;
 
 import android.annotation.TargetApi;
 import android.graphics.Rect;

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/CameraManager.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/CameraManager.java
@@ -24,7 +24,6 @@ import android.view.Surface;
 import android.view.SurfaceHolder;
 
 import com.google.zxing.client.android.AmbientLightManager;
-import com.google.zxing.client.android.camera.CameraConfigurationUtils;
 import com.google.zxing.client.android.camera.open.OpenCameraInterface;
 import com.journeyapps.barcodescanner.Size;
 import com.journeyapps.barcodescanner.SourceData;


### PR DESCRIPTION
The class `CameraConfigurationUtils` exists in `com.google.zxing:android-core` as well. If an app would have dependencies to `zxing-android-embedded` as well as `com.google.zxing:android-core`, this would lead to a build error.
A simple solution for that is to move the class to a different namespace.