### PR TITLE
Correct minSdkVersion to 19

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ Features:
 
 A sample application is available in [Releases](https://github.com/journeyapps/zxing-android-embedded/releases).
 
-By default, Android SDK 24+ is required because of `zxing:core` 3.4.0. To support SDK 14+, see [Older SDK versions](#older-sdk-versions). 
+By default, Android SDK 19+ is required because of `zxing:core` 3.4.0. To support SDK 14+, see [Older SDK versions](#older-sdk-versions).
 
 ## Adding aar dependency with Gradle
 
-From version 4.x, only Android SDK 24+ is supported by default, and androidx is required.
+From version 4.x, only Android SDK 19+ is supported by default, and androidx is required.
 
 Add the following to your `build.gradle` file:
 
@@ -39,7 +39,7 @@ android {
 
 ## Older SDK versions
 
-For Android SDK versions < 24, you can downgrade `zxing:core` to 3.3.0 or earlier for Android 14+ support:
+For Android SDK versions < 19, you can downgrade `zxing:core` to 3.3.0 or earlier for Android 14+ support:
 
 ```groovy
 repositories {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion project.androidTargetSdk
 
     defaultConfig {
-        minSdkVersion 24
+        minSdkVersion 19
         targetSdkVersion project.androidTargetSdk
         versionCode 411
         versionName "4.1.1"

--- a/zxing-android-embedded/build.gradle
+++ b/zxing-android-embedded/build.gradle
@@ -45,7 +45,7 @@ android {
         unitTests.returnDefaultValues = true
     }
     defaultConfig {
-        minSdkVersion 24
+        minSdkVersion 19
     }
 
     buildTypes {


### PR DESCRIPTION
zxing:core never increased the minimum version to 24. It increased it to
19: https://github.com/zxing/zxing/blob/44267115/android/AndroidManifest.xml#L34

This most recent bump happened here: https://github.com/zxing/zxing/commit/04595508b

Now, this disagrees with the release notes of 3.4.0:
https://github.com/zxing/zxing/releases/tag/zxing-3.4.0 which say the
minimum verison is API 24 due to Java 8. But these days, AGP desugars
Java 8 automatically, so you can, in fact, use it with older APIs.

See this for more information:
https://developer.android.com/studio/releases#4-0-0-desugar

---

CC @msfjarvis
Also https://github.com/journeyapps/zxing-android-embedded/issues/606#issuecomment-778094849