### PR TITLE
Maven Central

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ maven-repository
 local.properties
 mvn-clone
 *.keystore
+.project
+.settings
+.classpath

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Add the following to your `build.gradle` file:
 
 ```groovy
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {
-    implementation 'com.journeyapps:zxing-android-embedded:4.1.0'
+    implementation 'com.journeyapps:zxing-android-embedded:4.2.0'
     implementation 'androidx.appcompat:appcompat:1.0.2'
 }
 
@@ -43,11 +43,11 @@ For Android SDK versions < 24, you can downgrade `zxing:core` to 3.3.0 or earlie
 
 ```groovy
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {
-    implementation('com.journeyapps:zxing-android-embedded:4.1.0') { transitive = false }
+    implementation('com.journeyapps:zxing-android-embedded:4.2.0') { transitive = false }
     implementation 'androidx.appcompat:appcompat:1.0.2'
     implementation 'com.google.zxing:core:3.3.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,23 +1,34 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        jcenter {
+            content {
+                // https://youtrack.jetbrains.com/issue/IDEA-261387
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.3'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
     }
 }
 
 subprojects {
     repositories {
         google()
-        jcenter()
         mavenLocal()
+        mavenCentral()
+        jcenter {
+            content {
+                // https://youtrack.jetbrains.com/issue/IDEA-261387
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 
-    version = '4.1.1'
+    version = '4.2.0'
     group = 'com.journeyapps'
 
     ext.androidTargetSdk = 28

--- a/zxing-android-embedded/build.gradle
+++ b/zxing-android-embedded/build.gradle
@@ -1,9 +1,34 @@
 apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
-apply plugin: 'com.jfrog.bintray'
-
+apply plugin: 'signing'
 
 ext.artifactId = 'zxing-android-embedded'
+
+
+// Publishing config from https://getstream.io/blog/publishing-libraries-to-mavencentral-2021/
+ext["signing.keyId"] = ''
+ext["signing.password"] = ''
+ext["signing.secretKeyRingFile"] = ''
+ext["ossrhUsername"] = ''
+ext["ossrhPassword"] = ''
+ext["sonatypeStagingProfileId"] = ''
+
+File secretPropsFile = project.rootProject.file('local.properties')
+if (secretPropsFile.exists()) {
+    Properties p = new Properties()
+    p.load(new FileInputStream(secretPropsFile))
+    p.each { name, value ->
+        ext[name] = value
+    }
+} else {
+    ext["signing.keyId"] = System.getenv('SIGNING_KEY_ID')
+    ext["signing.password"] = System.getenv('SIGNING_PASSWORD')
+    ext["signing.secretKeyRingFile"] = System.getenv('SIGNING_SECRET_KEY_RING_FILE')
+    ext["ossrhUsername"] = System.getenv('OSSRH_USERNAME')
+    ext["ossrhPassword"] = System.getenv('OSSRH_PASSWORD')
+    ext["sonatypeStagingProfileId"] = System.getenv('SONATYPE_STAGING_PROFILE_ID')
+}
+
 
 dependencies {
     api project.zxingCore
@@ -74,11 +99,30 @@ project.afterEvaluate {
                 artifact sourceJar
                 
                 pom {
+                    name = project.artifactId
+                    description = 'Barcode scanner library for Android, based on the ZXing decoder'
+                    url = 'https://github.com/journeyapps/zxing-android-embedded'
+
                     licenses {
                         license {
                             name = 'The Apache License, Version 2.0'
                             url = 'https://github.com/journeyapps/zxing-android-embedded/blob/master/COPYING'
                         }
+                    }
+
+                    developers {
+                        developer {
+                            id = ''
+                            name = 'Ralf Kistner'
+                            email = 'ralf@journeyapps.com'
+                            organization = 'Journey Mobile, Inc'
+                            organizationUrl = 'https://journeyapps.com'
+                        }
+                    }
+                    scm {
+                        connection = 'scm:git:github.com/journeyapps/zxing-android-embedded.git'
+                        developerConnection = 'scm:git:ssh://github.com/journeyapps/zxing-android-embedded.git'
+                        url = 'https://github.com/journeyapps/zxing-android-embedded'
                     }
                 }
 
@@ -100,23 +144,20 @@ project.afterEvaluate {
                 }
             }
         }
-    }
-}
 
-// To release, place bintray_user and bintray_key properties in ~/.gradle/gradle.properties,
-// and run ./gradlew clean assembleRelease bintrayUpload
-
-if (project.hasProperty('bintray_user') && project.hasProperty('bintray_key')) {
-    bintray {
-        user = bintray_user
-        key = bintray_key
-        publications = ['maven']
-        publish = true
-        pkg {
-            userOrg = 'journeyapps'
-            repo = 'maven'
-            name = 'zxing-android-embedded'
+        repositories {
+            maven {
+                name = "sonatype"
+                url = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                credentials {
+                    username ossrhUsername
+                    password ossrhPassword
+                }
+            }
         }
     }
 }
 
+signing {
+    sign publishing.publications
+}


### PR DESCRIPTION
Update metadata and scripts to publish to Maven Central instead of JCenter.

The `trove4j` lib is still required internally for building, and only available on JCenter (see https://youtrack.jetbrains.com/issue/IDEA-261387). It is not required to use this library though.

Fixes #606.