### PR TITLE
fix mistake in README for Older SDK versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ repositories {
 }
 
 dependencies {
-    implementation('com.journeyapps:zxing-android-embedded:4.2.0') { transitive = false }
+    implementation('com.journeyapps:zxing-android-embedded:3.6.0') { transitive = false }
     implementation 'androidx.appcompat:appcompat:1.0.2'
     implementation 'com.google.zxing:core:3.3.0'
 }


### PR DESCRIPTION
The error in README for Android SDK versions < 24 was introduced in this commit:
https://github.com/journeyapps/zxing-android-embedded/commit/545672bb8f0cbb15df202b353c1d8d548b0ccfc5
As said some 20 lines above: "From version 4.x, only Android SDK 24+ is supported by default"
The last version working with SDK < 24 is 3.6.0.