### PR TITLE
Disable jetifier

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-android.enableJetifier=true
+android.enableJetifier=false
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536M


### PR DESCRIPTION
zxing-android-embedded is not using android.support library, any more.

So, it's time to disable jetifier.