### PR TITLE
Use minimal dependencies

### DIFF
--- a/zxing-android-embedded/build.gradle
+++ b/zxing-android-embedded/build.gradle
@@ -33,7 +33,8 @@ if (secretPropsFile.exists()) {
 dependencies {
     api project.zxingCore
 
-    api 'androidx.legacy:legacy-support-v4:1.0.0'
+    implementation 'androidx.core:core:1.0.0'
+    implementation "androidx.fragment:fragment:1.0.0"
 
     testImplementation 'junit:junit:4.13'
     testImplementation "org.mockito:mockito-core:1.9.5"


### PR DESCRIPTION
zxing-android-embedded is using AndroidX Core, Fragment libraries only.

But `legacy-support-v4` contains other dependencies such as media, legacy libraries which are not used by zxing-android-embedded