### PR TITLE
Make auto-focus delay configurable

### DIFF
--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/AutoFocusManager.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/AutoFocusManager.java
@@ -35,9 +35,7 @@ public final class AutoFocusManager {
     private boolean stopped;
     private boolean focusing;
     private final boolean useAutoFocus;
-
     private long autoFocusDelay;
-
     private final Camera camera;
     private Handler handler;
 

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/AutoFocusManager.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/AutoFocusManager.java
@@ -32,11 +32,12 @@ public final class AutoFocusManager {
 
     private static final String TAG = AutoFocusManager.class.getSimpleName();
 
-    private static final long AUTO_FOCUS_INTERVAL_MS = 2000L;
-
     private boolean stopped;
     private boolean focusing;
     private final boolean useAutoFocus;
+
+    private long autoFocusDelay;
+
     private final Camera camera;
     private Handler handler;
 
@@ -76,13 +77,14 @@ public final class AutoFocusManager {
         this.camera = camera;
         String currentFocusMode = camera.getParameters().getFocusMode();
         useAutoFocus = settings.isAutoFocusEnabled() && FOCUS_MODES_CALLING_AF.contains(currentFocusMode);
+        autoFocusDelay = settings.getAutoFocusDelay();
         Log.i(TAG, "Current focus mode '" + currentFocusMode + "'; use auto focus? " + useAutoFocus);
         start();
     }
 
     private synchronized void autoFocusAgainLater() {
         if (!stopped && !handler.hasMessages(MESSAGE_FOCUS)) {
-            handler.sendMessageDelayed(handler.obtainMessage(MESSAGE_FOCUS), AUTO_FOCUS_INTERVAL_MS);
+            handler.sendMessageDelayed(handler.obtainMessage(MESSAGE_FOCUS), autoFocusDelay);
         }
     }
 

--- a/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/CameraSettings.java
+++ b/zxing-android-embedded/src/com/journeyapps/barcodescanner/camera/CameraSettings.java
@@ -11,6 +11,7 @@ public class CameraSettings {
     private boolean barcodeSceneModeEnabled = false;
     private boolean meteringEnabled = false;
     private boolean autoFocusEnabled = true;
+    private long autoFocusDelay = 2000L;
     private boolean continuousFocusEnabled = false;
     private boolean exposureEnabled = false;
     private boolean autoTorchEnabled = false;
@@ -112,6 +113,19 @@ public class CameraSettings {
         } else {
             focusMode = null;
         }
+    }
+
+    /**
+     * Returns the delay of auto-focus, in milliseconds
+     *
+     * @return delay in milliseconds
+     */
+    public long getAutoFocusDelay() {
+        return autoFocusDelay;
+    }
+
+    public void setAutoFocusDelay(long autoFocusDelay) {
+        this.autoFocusDelay = autoFocusDelay;
     }
 
     /**


### PR DESCRIPTION
It's not clear why the focus delay is fixed in 2000 milliseconds and cannot be changed.

I propose to make it configurable so that anyone can tune it to their specific needs.