### PR TITLE
ignore screenOrientation

### DIFF
--- a/zxing-android-embedded/AndroidManifest.xml
+++ b/zxing-android-embedded/AndroidManifest.xml
@@ -14,7 +14,9 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.google.zxing.client.android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.google.zxing.client.android">
 
   <uses-permission android:name="android.permission.CAMERA"/>
 
@@ -35,7 +37,8 @@
                 android:screenOrientation="sensorLandscape"
                 android:stateNotNeeded="true"
                 android:theme="@style/zxing_CaptureTheme"
-                android:windowSoftInputMode="stateAlwaysHidden"/>
+                android:windowSoftInputMode="stateAlwaysHidden"
+          tools:ignore="DiscouragedApi" />
   </application>
 
 </manifest>


### PR DESCRIPTION
FYI : Google recommendation on Android 16 : "Remove resizing and orientation restrictions from your app to support large screen devices"

<img width="902" alt="image" src="https://github.com/user-attachments/assets/88a9498a-2b21-46d1-9232-5443996538a8" />

